### PR TITLE
fix urls in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><code>chartmogul-node</code> provides convenient Node.js bindings for <a href="https://dev.chartmogul.com">ChartMogul's API</a>.</p>
 <p align="center">
-  <a href="https://www.npmjs.com/package/chartmogul-node"><img src="https://img.shields.io/npm/v/chartmogul-node.svg?maxAge=2592000" alt="npm Package" /></a>
+  <a href="https://www.npmjs.com/package/chartmogul-node"><img src="https://badge.fury.io/js/chartmogul-node.svg" alt="npm Package" /></a>
   <a href="https://travis-ci.org/chartmogul/chartmogul-node"><img src="https://travis-ci.org/chartmogul/chartmogul-node.svg?branch=master" alt="Build Status"/></a>
 </p>
 <hr>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><code>chartmogul-node</code> provides convenient Node.js bindings for <a href="https://dev.chartmogul.com">ChartMogul's API</a>.</p>
 <p align="center">
-  <a href="https://github.com/chartmogul/chartmogul-node"><img src="https://img.shields.io/npm/v/chartmogul-node.svg?maxAge=2592000" alt="npm Package" /></a>
+  <a href="https://www.npmjs.com/package/chartmogul-node"><img src="https://img.shields.io/npm/v/chartmogul-node.svg?maxAge=2592000" alt="npm Package" /></a>
   <a href="https://travis-ci.org/chartmogul/chartmogul-node"><img src="https://travis-ci.org/chartmogul/chartmogul-node.svg?branch=master" alt="Build Status"/></a>
 </p>
 <hr>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center"><code>chartmogul-node</code> provides convenient Node.js bindings for <a href="https://dev.chartmogul.com">ChartMogul's API</a>.</p>
 <p align="center">
+  <a href="https://github.com/chartmogul/chartmogul-node"><img src="https://img.shields.io/npm/v/chartmogul-node.svg?maxAge=2592000" alt="npm Package" /></a>
   <a href="https://travis-ci.org/chartmogul/chartmogul-node"><img src="https://travis-ci.org/chartmogul/chartmogul-node.svg?branch=master" alt="Build Status"/></a>
 </p>
 <hr>

--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chartmogul/chartmogul-js.git"
+    "url": "https://github.com/chartmogul/chartmogul-node.git"
   },
   "keywords": [
     "chartmogul",
     "api"
   ],
-  "author": "",
+  "author": "ChartMogul Ltd. <support@chartmogul.com>",
   "contributors": [
     "Mahmudul Hassan <rezatxe@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/chartmogul/chartmogul-js/issues"
+    "url": "https://github.com/chartmogul/chartmogul-node/issues"
   },
-  "homepage": "https://github.com/chartmogul/chartmogul-js#readme",
+  "homepage": "https://github.com/chartmogul/chartmogul-node",
   "engines": {
     "node": ">=4"
   },


### PR DESCRIPTION
Fixes all the urls in `package.json` so the links on our npm registry page are pointing to correct repo. Additionally, fill author field and add npm package badge to readme.