### PR TITLE
Customer update

### DIFF
--- a/lib/chartmogul/enrichment/customer.js
+++ b/lib/chartmogul/enrichment/customer.js
@@ -19,6 +19,17 @@ class Customer extends Resource {
     return Resource.request(config, 'GET', path, {}, callback);
   }
 
+  // @Override
+  static patch (config, customerUuid, data, callback) {
+    return this.request(
+      config,
+      'PATCH',
+      `/v1/customers/${customerUuid}`,
+      data,
+      callback
+    );
+  }
+
 }
 
 module.exports = Customer;

--- a/lib/chartmogul/import/customer.js
+++ b/lib/chartmogul/import/customer.js
@@ -7,6 +7,17 @@ class Customer extends Resource {
   static get path () {
     return '/v1/import/customers{/customerUuid}';
   }
+
+  // @Override
+  static patch (config, customerUuid, data, callback) {
+    return this.request(
+      config,
+      'PATCH',
+      `/v1/import/customers/${customerUuid}`,
+      data,
+      callback
+    );
+  }
 }
 
 module.exports = Customer;

--- a/lib/chartmogul/import/customer.js
+++ b/lib/chartmogul/import/customer.js
@@ -7,17 +7,7 @@ class Customer extends Resource {
   static get path () {
     return '/v1/import/customers{/customerUuid}';
   }
-
-  // @Override
-  static patch (config, customerUuid, data, callback) {
-    return this.request(
-      config,
-      'PATCH',
-      `/v1/import/customers/${customerUuid}`,
-      data,
-      callback
-    );
-  }
+  
 }
 
 module.exports = Customer;

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -12,6 +12,7 @@ const mappings = {
   destroy: 'DELETE',
   cancel: 'PATCH',
   retrieve: 'GET',
+  patch: 'PATCH',
   update: 'PUT',
   add: 'POST',
   remove: 'DELETE'

--- a/test/chartmogul/enrichment/customer.js
+++ b/test/chartmogul/enrichment/customer.js
@@ -106,4 +106,31 @@ describe('Enrichment#Customer', () => {
       expect(res).to.have.property('tags');
     });
   });
+
+  it('should update a customer', () => {
+    const customerUuid = 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc';
+
+    /* eslint-disable camelcase*/
+    const postBody = {
+      'lead_created_at': '2014-01-15 00:00:00'
+    };
+    /* eslint-enable camelcase*/
+
+    nock(config.API_BASE)
+      .patch(`/v1/customers/${customerUuid}`)
+      .reply(200, {
+        /* eslint-disable camelcase*/
+        uuid: 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc',
+        external_id: 'cus_0001',
+        name: 'Adam Smith',
+        data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+        /* eslint-enable camelcase*/
+      });
+
+    return Customer.patch(config, customerUuid, postBody)
+    .then(res => {
+      expect(res).to.have.property('uuid');
+    });
+  });
+  
 });

--- a/test/chartmogul/import/customer.js
+++ b/test/chartmogul/import/customer.js
@@ -78,30 +78,4 @@ describe('Customer', () => {
 
     return Customer.destroy(config, uuid);
   });
-
-  it('should update a customer', () => {
-    const customerUuid = 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc';
-
-    /* eslint-disable camelcase*/
-    const postBody = {
-      'lead_created_at': '2014-01-15 00:00:00'
-    };
-    /* eslint-enable camelcase*/
-
-    nock(config.API_BASE)
-      .patch(`/v1/import/customers/${customerUuid}`)
-      .reply(200, {
-        /* eslint-disable camelcase*/
-        uuid: 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc',
-        external_id: 'cus_0001',
-        name: 'Adam Smith',
-        data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-        /* eslint-enable camelcase*/
-      });
-
-    return Customer.patch(config, customerUuid, postBody)
-    .then(res => {
-      expect(res).to.have.property('uuid');
-    });
-  });
 });

--- a/test/chartmogul/import/customer.js
+++ b/test/chartmogul/import/customer.js
@@ -78,4 +78,30 @@ describe('Customer', () => {
 
     return Customer.destroy(config, uuid);
   });
+
+  it('should update a customer', () => {
+    const customerUuid = 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc';
+
+    /* eslint-disable camelcase*/
+    const postBody = {
+      'lead_created_at': '2014-01-15 00:00:00'
+    };
+    /* eslint-enable camelcase*/
+
+    nock(config.API_BASE)
+      .patch(`/v1/import/customers/${customerUuid}`)
+      .reply(200, {
+        /* eslint-disable camelcase*/
+        uuid: 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc',
+        external_id: 'cus_0001',
+        name: 'Adam Smith',
+        data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+        /* eslint-enable camelcase*/
+      });
+
+    return Customer.patch(config, customerUuid, postBody)
+    .then(res => {
+      expect(res).to.have.property('uuid');
+    });
+  });
 });


### PR DESCRIPTION
Adds support for the customer update endpoint.

More info:

- https://dev.chartmogul.com/docs/tracking-leads-and-free-trials-using-the-api
- https://dev.chartmogul.com/reference#update-a-customer

The following request is made possible with these changes:

```
curl -X PATCH "https://api.chartmogul.com/v1/customers/cus_ab223d54-75b4-431b-adb2-eb6b9e234571" \
     -u YOUR_ACCOUNT_TOKEN:YOUR_SECRET_KEY \
     -H "Content-Type: application/json" \
     -d '{
          "lead_created_at": "2015-01-01 00:00:00",
          "free_trial_started_at" : "2015-06-13 15:45:13"
         }'
```

```js
var data = {
    "lead_created_at": "2015-01-01 00:00:00",
    "free_trial_started_at" : "2015-06-13 15:45:13"
};

ChartMogul.Import.Customer.patch(config, customerUuid, data);
```