### PR TITLE
customer-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ ChartMogul.Enrichment.Customer.all(config, query)
 ChartMogul.Enrichment.Customer.search(config, {
   email: 'adam@smith.com'
 })
+
+ChartMogul.Enrichment.Customer.merge(config, {
+  "from": {"customer_uuid": "cus_5915ee5a-babd-406b-b8ce-d207133fb4cb"},
+  "into": {"customer_uuid": "cus_2123290f-09c8-4628-a205-db5596bd58f7"}
+})
+
+ChartMogul.Enrichment.Customer.modify(config, "cus_5915ee5a-babd-406b-b8ce-d207133fb4cb", {
+  "lead_created_at": "2015-01-01 00:00:00",
+  "free_trial_started_at": "2015-06-13 15:45:13"
+})
 ```
 
 #### [Customer Attributes](https://dev.chartmogul.com/docs/customer-attributes)

--- a/lib/chartmogul/enrichment/customer.js
+++ b/lib/chartmogul/enrichment/customer.js
@@ -20,11 +20,21 @@ class Customer extends Resource {
   }
 
   // @Override
-  static patch (config, customerUuid, data, callback) {
+  static modify (config, customerUuid, data, callback) {
     return this.request(
       config,
       'PATCH',
       `/v1/customers/${customerUuid}`,
+      data,
+      callback
+    );
+  }
+
+  static merge (config, data, callback) {
+    return this.request(
+      config,
+      'POST',
+      '/v1/customers/merges',
       data,
       callback
     );

--- a/lib/chartmogul/import/customer.js
+++ b/lib/chartmogul/import/customer.js
@@ -7,7 +7,7 @@ class Customer extends Resource {
   static get path () {
     return '/v1/import/customers{/customerUuid}';
   }
-  
+
 }
 
 module.exports = Customer;

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -11,9 +11,11 @@ const mappings = {
   create: 'POST',
   destroy: 'DELETE',
   cancel: 'PATCH',
+  merge: 'PATCH',
   retrieve: 'GET',
   patch: 'PATCH',
   update: 'PUT',
+  modify: 'PATCH',
   add: 'POST',
   remove: 'DELETE'
 };

--- a/test/chartmogul/enrichment/customer.js
+++ b/test/chartmogul/enrichment/customer.js
@@ -117,7 +117,7 @@ describe('Enrichment#Customer', () => {
     /* eslint-enable camelcase*/
 
     nock(config.API_BASE)
-      .patch(`/v1/customers/${customerUuid}`)
+      .patch(`/v1/customers/${customerUuid}`, postBody)
       .reply(200, {
         /* eslint-disable camelcase*/
         uuid: 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc',
@@ -132,5 +132,23 @@ describe('Enrichment#Customer', () => {
       expect(res).to.have.property('uuid');
     });
   });
-  
+
+  it('should merge customers', () => {
+    /* eslint-disable camelcase*/
+    const postBody = {
+      'from': {'customer_uuid': 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc'},
+      'into': {'customer_uuid': 'cus_ab223d54-75b4-431b-adb2-eb6b9e234571'}
+    };
+    /* eslint-enable camelcase*/
+
+    nock(config.API_BASE)
+      .post('/v1/customers/merges', postBody)
+      .reply(202, {});
+
+    return Customer.merge(config, postBody)
+    .then(res => {
+      expect(202);
+      expect(res).to.be.instanceof(Object);
+    });
+  });
 });


### PR DESCRIPTION
Makes the following merge customer request possible:

```
curl -X POST "https://api.chartmogul.com/v1/customers/merges" \
       -u <token>:<secret>
       -H "Content-Type: application/json"
       -d '{
             "from": {"customer_uuid": "cus_de305d54-75b4-431b-adb2-eb6b9e546012"},
             "into": {"customer_uuid": "cus_ab223d54-75b4-431b-adb2-eb6b9e234571"}
           }'
```

```
ChartMogul.Enrichment.Customer.merge(config, {
  "from": {"customer_uuid": "cus_5915ee5a-babd-406b-b8ce-d207133fb4cb"},
  "into": {"customer_uuid": "cus_2123290f-09c8-4628-a205-db5596bd58f7"}
})
```

Resolves https://github.com/chartmogul/chartmogul-node/issues/10
Reference: https://dev.chartmogul.com/reference#merge-customers

NB. Also changes Enrichment.Customer.patch to Enrichment.Customer.modify.