### PR TITLE
The response from API should get included by default

### DIFF
--- a/lib/chartmogul/errors/chartmogul-error.js
+++ b/lib/chartmogul/errors/chartmogul-error.js
@@ -2,9 +2,8 @@
 
 class ChartMogulError extends Error {
   constructor (message, httpStatus, response) {
-    super(message);
+    super(message + ' ' + JSON.stringify(response));
     this.name = this.constructor.name;
-    this.message = message;
     this.response = response;
     this.httpStatus = httpStatus;
     Error.captureStackTrace(this, this.constructor.name);

--- a/test/chartmogul/resource.js
+++ b/test/chartmogul/resource.js
@@ -81,15 +81,15 @@ describe('Resource', () => {
   it('should throw ResourceInvalidError', done => {
     nock(config.API_BASE)
       .get('/')
-      .reply(422, 'error message');
+      .reply(422, '{"error": "message"}');
     return Customer.request(config, 'GET', '/')
       .then(res => done(new Error('Should throw error')))
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.ResourceInvalidError);
         expect(e.httpStatus).to.equal(422);
-        expect(e.response).to.equal('error message');
+        expect(e.response.error).to.equal('message');
         expect(e.message)
-          .to.equal('The Customer  could not be created or updated.');
+          .to.equal('The Customer  could not be created or updated. {"error":"message"}');
         done();
       });
   });


### PR DESCRIPTION
People get confused about the general messages. The response field is hidden away in the object & users of the library don't realize it. Matching should be done on Class and parsed response.