### PR TITLE
Subscription.modify; Overrides now correctly support callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ ChartMogul.Import.Transaction.create(config, invoiceUuid, data)
 #### [Subscriptions](https://dev.chartmogul.com/docs/subscriptions)
 
 ```js
-ChartMogul.Import.Subscription.cancel(config, subscriptionUuid, data)
 ChartMogul.Import.Subscription.all(config, customerUuid, query)
+ChartMogul.Import.Subscription.cancel(config, subscriptionUuid, {cancelled_at: ""})
+ChartMogul.Import.Subscription.modify(config, subscriptionUuid, {cancellation_dates: []})
 ```
 
 ### Enrichment API

--- a/lib/chartmogul/enrichment/customer.js
+++ b/lib/chartmogul/enrichment/customer.js
@@ -19,27 +19,11 @@ class Customer extends Resource {
     return Resource.request(config, 'GET', path, {}, callback);
   }
 
-  // @Override
-  static modify (config, customerUuid, data, callback) {
-    return this.request(
-      config,
-      'PATCH',
-      `/v1/customers/${customerUuid}`,
-      data,
-      callback
-    );
-  }
-
-  static merge (config, data, callback) {
-    return this.request(
-      config,
-      'POST',
-      '/v1/customers/merges',
-      data,
-      callback
-    );
-  }
-
 }
+
+// @Override
+Customer.modify = Resource._method('PATCH', '/v1/customers/{customerUuid}');
+
+Customer.merge = Resource._method('POST', '/v1/customers/merges');
 
 module.exports = Customer;

--- a/lib/chartmogul/import/subscription.js
+++ b/lib/chartmogul/import/subscription.js
@@ -5,19 +5,12 @@ const Resource = require('../resource.js');
 class Subscription extends Resource {
 
   static get path () {
-    return '/v1/import/customers/{customerUuid}/subscriptions{/subscriptionUuid}';
+    return '/v1/import/subscriptions{/subscriptionUuid}';
   }
 
-  // @Override
-  static cancel (config, subscriptionUuid, data, callback) {
-    return this.request(
-      config,
-      'PATCH',
-      `/v1/import/subscriptions/${subscriptionUuid}`,
-      data,
-      callback
-    );
-  }
 }
+
+// @Override
+Subscription.all = Resource._method('GET', '/v1/import/customers/{customerUuid}/subscriptions');
 
 module.exports = Subscription;

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -20,7 +20,7 @@ const mappings = {
   remove: 'DELETE'
 };
 
-/* API Resource Class*/
+/* API Resource Class */
 class Resource {
 
   /**
@@ -126,25 +126,28 @@ class Resource {
       });
     });
   }
+
+  static _method (verb, pathOverride) {
+    return function (config) {
+      // node v4.x doesn't support rest param
+      let args = Array.from(arguments).splice(1);
+      let cb, data;
+      if (typeof args[args.length - 1] === 'function') {
+        cb = args.pop();
+      }
+      if (typeof args[args.length - 1] === 'object') {
+        data = args.pop();
+      }
+      let path = util.expandPath(pathOverride || this.path, args);
+
+      return this.request(config, verb, path, data, cb);
+    };
+  }
 }
 
 // Define actions
 Object.keys(mappings).forEach(methodName => {
-  let verb = mappings[methodName];
-  Resource[methodName] = function (config) {
-    // node v4.x doesn't support rest param
-    let args = Array.from(arguments).splice(1);
-    let cb, data;
-    if (typeof args[args.length - 1] === 'function') {
-      cb = args.pop();
-    }
-    if (typeof args[args.length - 1] === 'object') {
-      data = args.pop();
-    }
-    let path = util.expandPath(this.path, args);
-
-    return this.request(config, verb, path, data, cb);
-  };
+  Resource[methodName] = Resource._method(mappings[methodName]);
 });
 
 module.exports = Resource;

--- a/test/chartmogul/import/subscription.js
+++ b/test/chartmogul/import/subscription.js
@@ -10,23 +10,23 @@ describe('Subscription', () => {
   it('should cancel a subscription', () => {
     const subscriptionUuid = 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88';
 
-    /* eslint-disable camelcase*/
+    /* eslint-disable camelcase */
     const postBody = {
       'cancelled_at': '2016-01-15 00:00:00'
     };
-    /* eslint-enable camelcase*/
+    /* eslint-enable camelcase */
 
     nock(config.API_BASE)
       .patch(`/v1/import/subscriptions/${subscriptionUuid}`)
       .reply(200, {
-        /* eslint-disable camelcase*/
+        /* eslint-disable camelcase */
         uuid: 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88',
         external_id: 'sub_0001',
         cancellation_dates: [ '2016-01-15T00:00:00.000Z' ],
         customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
         plan_uuid: 'pl_cff3a63c-3915-435e-a675-85a8a8ef4454',
         data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-        /* eslint-enable camelcase*/
+        /* eslint-enable camelcase */
       });
 
     return Subscription.cancel(config, subscriptionUuid, postBody)
@@ -35,13 +35,42 @@ describe('Subscription', () => {
     });
   });
 
+  it('should modify the cancellation dates of the subscription', () => {
+    const subscriptionUuid = 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88';
+
+      /* eslint-disable camelcase */
+    const postBody = {
+      'cancellation_dates': ['2016-02-15 00:00:00']
+    };
+      /* eslint-enable camelcase */
+
+    nock(config.API_BASE)
+            .patch(`/v1/import/subscriptions/${subscriptionUuid}`)
+            .reply(200, {
+              /* eslint-disable camelcase */
+              uuid: 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88',
+              external_id: 'sub_0001',
+              cancellation_dates: [ '2016-02-15T00:00:00.000Z' ],
+              customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
+              plan_uuid: 'pl_cff3a63c-3915-435e-a675-85a8a8ef4454',
+              data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+              /* eslint-enable camelcase */
+            });
+
+    return Subscription.modify(config, subscriptionUuid, postBody)
+            .then(res => {
+              expect(res).to.have.property('cancellation_dates');
+              expect(res.cancellation_dates).to.be.instanceof(Array);
+            });
+  });
+
   it('should get all subscriptions', () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
     .get('/v1/import/customers/' + customerUUID + '/subscriptions')
     .reply(200, {
-      /* eslint-disable camelcase*/
+      /* eslint-disable camelcase */
       customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
       subscriptions: [{
         uuid: 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88',
@@ -52,7 +81,7 @@ describe('Subscription', () => {
       }],
       current_page: 1,
       total_pages: 1
-      /* eslint-enable camelcase*/
+      /* eslint-enable camelcase */
     });
 
     return Subscription.all(config, customerUUID)


### PR DESCRIPTION
Thanks to @yellowbrickc for bringing this up.

I made it possible to call `modify` on `Subscription` with correct path, also added mention in the `README`.
Also reworked overrides, because the previous way totally omitted the callback recognition mechanism, which was in other methods. Now it's less code and concise.

The test case is copied from @yellowbrickc 's PR.