### PR TITLE
Configurable api base

### DIFF
--- a/lib/chartmogul/config.js
+++ b/lib/chartmogul/config.js
@@ -4,9 +4,10 @@ const VERSION = require('../../package.json').version;
 const API_BASE = 'https://api.chartmogul.com';
 
 class Config {
-  constructor (accountToken, secretKey) {
+  constructor (accountToken, secretKey, apiBase) {
     this.accountToken = accountToken;
     this.secretKey = secretKey;
+    this.apiBase = apiBase ? apiBase : API_BASE;
   }
   getAccountToken () {
     return this.accountToken;
@@ -20,7 +21,7 @@ class Config {
   }
 
   get API_BASE () {
-    return API_BASE;
+    return this.apiBase;
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {


### PR DESCRIPTION
Configurable API base, optional, it defaults to prod API, so this change keeps the client library backwards compatible.