### PR TITLE
Fix bug in ChartMogul.Invoice.all(config, query)

### DIFF
--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -14,11 +14,11 @@ Invoice.all_customer = Invoice.all;
 
 Invoice.all_any = Resource._method('GET', '/v1/invoices');
 
-Invoice.all = function (config, params, cb) {
+Invoice.all = function (config, params) {
   if (typeof params === 'string') {
-    return Invoice.all_customer(config, params, cb);
+    return Invoice.all_customer.apply(this, arguments);
   } else {
-    return Invoice.all_any(config, params, cb);
+    return Invoice.all_any.apply(this, arguments);
   }
 };
 


### PR DESCRIPTION
Implementing ChartMogul.Invoice.all(config, query) as a promise, had a bug where the query (data) object was not passed correctly.

Since no callback parameter is given to the function, and "undefined" was passed to the underlying _method (in resource.js). This resulted in "undefined" being passed as query parameter - hence all invoices were always returned.

Changed to simply pass arguments rather than a specific number of arguments.

This bug may also be present for other parts.