### PR TITLE
Add build on latest NodeJS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - node
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
There's now 12.x version, so I added "latest" to the list of building environments to assure forward compatibility.