### PR TITLE
Add Account API endpoint [ch28502]

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ ChartMogul.Metrics.Customer.activities(config, customerUuid, query)
 ChartMogul.Metrics.Customer.subscriptions(config, customerUuid, query)
 ```
 
+### Account
+
+Available methods:
+
+```js
+ChartMogul.Account.retrieve(config)
+```
+
 
 ### Errors
 

--- a/lib/chartmogul.js
+++ b/lib/chartmogul.js
@@ -16,6 +16,8 @@ const Transaction = require('./chartmogul/transaction');
 const CustomAttribute = require('./chartmogul/custom-attribute');
 const Tag = require('./chartmogul/tag');
 
+const Account = require('./chartmogul/account');
+
 const Config = require('./chartmogul/config');
 
 // Deprecated modules
@@ -36,7 +38,8 @@ const ChartMogul = {
   PlanGroup,
   Subscription,
   Tag,
-  Transaction
+  Transaction,
+  Account
 };
 
 Object.assign(ChartMogul, errors);

--- a/lib/chartmogul/account.js
+++ b/lib/chartmogul/account.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Resource = require('./resource.js');
+
+class Account extends Resource {
+  static get path () {
+    return '/v1/account';
+  }
+}
+
+module.exports = Account;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/account.js
+++ b/test/chartmogul/account.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const ChartMogul = require('../../lib/chartmogul');
+const config = new ChartMogul.Config('token', 'secret');
+const expect = require('chai').expect;
+const nock = require('nock');
+const Account = ChartMogul.Account;
+
+describe('Account', () => {
+  it('should retrieve the details of current account', () => {
+    nock(config.API_BASE)
+      .get('/v1/account')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        name: 'Example Test Company',
+        currency: 'EUR',
+        time_zone: 'Europe/Berlin',
+        week_start_on: 'sunday'
+      /* eslint-enable camelcase */
+      });
+
+    return Account.retrieve(config, (err, res) => {
+      if (err) {
+        return err;
+      }
+      expect(res.name).to.be.equal('Example Test Company');
+      expect(res.currency).to.be.equal('EUR');
+      expect(res.time_zone).to.be.equal('Europe/Berlin');
+      expect(res.week_start_on).to.be.equal('sunday');
+    });
+  });
+});


### PR DESCRIPTION
### Account Endpoint

```js
ChartMogul.Account.retrieve(config)
```

Makes the following account-level details available via API call:
- name
- time zone
- currency
- week start on

Find more information [here](https://www.notion.so/chartmogul/WIP-App-Make-account-details-available-via-API-calls-379e0e91d8d94a37ae04ffdfcf57c8c7) on Notion.

[https://app.clubhouse.io/chartmogul/story/28502/update-libraries-for-account-api-endpoints](https://app.clubhouse.io/chartmogul/story/28502/update-libraries-for-account-api-endpoints)