### PR TITLE
Implement support for async activities export

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ ChartMogul.Metrics.ltv(config, query)
 ChartMogul.Metrics.Customer.activities(config, customerUuid, query)
 ChartMogul.Metrics.Customer.subscriptions(config, customerUuid, query)
 ChartMogul.Metrics.Activity.all(config, query)
+ChartMogul.Metrics.ActivitiesExport.create(config, query)
+ChartMogul.Metrics.ActivitiesExport.retrieve(config, id)
 ```
 
 ### Account

--- a/lib/chartmogul/metrics/activities_export.js
+++ b/lib/chartmogul/metrics/activities_export.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const Resource = require('../resource.js');
+
+class ActivitiesExport extends Resource {
+  static get path () {
+    return '/v1/activities_export/{activitiesExportUuid}';
+  }
+}
+
+ActivitiesExport.create = Resource._method('POST', '/v1/activities_export');
+
+module.exports = ActivitiesExport;

--- a/lib/chartmogul/metrics/index.js
+++ b/lib/chartmogul/metrics/index.js
@@ -3,6 +3,7 @@
 const Resource = require('../resource.js');
 const Customer = require('./customer');
 const Activity = require('./activity');
+const ActivitiesExport = require('./activities_export');
 const util = require('../util');
 
 class Metrics {
@@ -35,4 +36,5 @@ Object.keys(actions).forEach(method => {
 
 Metrics.Customer = Customer;
 Metrics.Activity = Activity;
+Metrics.ActivitiesExport = ActivitiesExport;
 module.exports = Metrics;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/metrics/activities_export.js
+++ b/test/chartmogul/metrics/activities_export.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const ChartMogul = require('../../../lib/chartmogul');
+const config = new ChartMogul.Config('token', 'secret');
+const expect = require('chai').expect;
+const nock = require('nock');
+const ActivitiesExport = ChartMogul.Metrics.ActivitiesExport;
+
+describe('ActivitiesExport', () => {
+  it('should create an activities export', () => {
+    const pendingExport = {
+      id: '7f554dba-4a41-4cb2-9790-2045e4c3a5b1',
+      status: 'pending',
+      file_url: null,
+      params: {
+        kind: 'activities',
+        params: {
+          activity_type: 'contraction',
+          start_date: '2020-01-01',
+          end_date: '2020-12-31'
+        }
+      },
+      expires_at: null,
+      created_at: '2021-07-12T14:46:56+00:00'
+    };
+
+    const query = {
+      'start-date': '2020-01-01',
+      'end-date': '2020-12-31',
+      type: 'contraction'
+    };
+
+    nock(config.API_BASE)
+      .post('/v1/activities_export')
+      .reply(200, pendingExport);
+
+    return ActivitiesExport.create(config, query)
+      .then(res => {
+        expect(res).to.be.deep.equal(pendingExport);
+      });
+  });
+
+  it('should retrieve a successful activities export after a period of time', () => {
+    const succeededExport = {
+      id: '7f554dba-4a41-4cb2-9790-2045e4c3a5b1',
+      status: 'succeeded',
+      file_url: 'https://chartmogul-customer-export.s3.eu-west-1.amazonaws.com/activities-acme-corp-91e1ca88-d747-4e25-83d9-2b752033bdba.zip',
+      params: {
+        kind: 'activities',
+        params: {
+          activity_type: 'contraction',
+          start_date: '2020-01-01',
+          end_date: '2020-12-31'
+        }
+      },
+      expires_at: '2021-07-19T14:46:58+00:00',
+      created_at: '2021-07-12T14:46:56+00:00'
+    };
+    nock(config.API_BASE)
+      .get('/v1/activities_export/7f554dba-4a41-4cb2-9790-2045e4c3a5b1')
+      .reply(200, succeededExport);
+
+    return ActivitiesExport.retrieve(config, '7f554dba-4a41-4cb2-9790-2045e4c3a5b1')
+      .then(res => {
+        expect(res).to.be.deep.equal(succeededExport);
+      });
+  });
+});


### PR DESCRIPTION
This PR implements support for a async activities export:

```
ChartMogul.Metrics.ActivitiesExport.create(
  config, 
  { 'start-date': '2020-01-01', 'end-date': '2021-07-01', type: 'contraction' }
)
.then(res => { console.log(res); })
.catch(e => console.error(e.message, e.httpStatus, e.response));

ChartMogul.Metrics.ActivitiesExport.retrieve(
  config, 
 id
)
.then(res => { console.log(res); })
.catch(e => console.error(e.message, e.httpStatus, e.response));
```