### PR TITLE
add support for cursor pagination in supported endpoints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18, '*']
+        node-version: [16, 18, '*']
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/4.0-Upgrade.md
+++ b/4.0-Upgrade.md
@@ -1,0 +1,30 @@
+# Upgrading to chartmogul-node 3.0.0
+
+This new version replaces the existing pagination for the `.all()` endpoints that used a combination of `page` and `per_page` parameters, and instead uses a `cursor` based pagination. So to list (as an example) Plans you now can:
+
+```javascript
+const ChartMogul = require('chartmogul-node');
+const config = new ChartMogul.Config('apiKey');
+
+// Getting the first page
+plans = ChartMogul.Plan.all(config, { per_page: 10, cursor: 'cursor==' })
+
+// This will return an array of plans (if available), and a cursor + has_more fields
+{
+    "plans": [
+        {
+            "uuid": "some_uuid",
+            "data_source_uuid": "some_uuid",
+            "name": "Master Plan"
+        }
+    ],
+    "has_more": true,
+    "cursor": "MjAyMy0wNy0yOFQwODowOToyMi4xNTQyMDMwMDBaJjk0NDQ0Mg=="
+}
+
+if (plans.has_more) {
+  more_plans = ChartMogul.Plan.all(config, { per_page: 10, cursor: plans.cursor })
+}
+```
+
+If you have existing code that relies on the `page` parameter, those requests will throw an error now alerting you of their deprecation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog],
+and this project adheres to [Semantic Versioning].
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+
+## [3.0.0] - 2023-09-15
+
+### Added
+- Support for cursor based pagination to `.all()` endpoints.
+- Changelog and 3.0.0 upgrade instructions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,6 @@ and this project adheres to [Semantic Versioning].
 ### Added
 - Support for cursor based pagination to `.all()` endpoints.
 - Changelog and 3.0.0 upgrade instructions.
+
+### Removed
+- Support for Node v14 because it reached EOL.

--- a/README.md
+++ b/README.md
@@ -112,13 +112,10 @@ ChartMogul.DataSource.destroy(config, dataSourceUuid)
 
 ```js
 ChartMogul.Customer.create(config, data)
-ChartMogul.Customer.all(config, {
-  page: 2,
-  per_page: 20
-})
+ChartMogul.Customer.all(config, { cursor: 'cursor==', per_page: 20 })
 ChartMogul.Customer.destroy(config, customerUuid)
 
-ChartMogul.Customer.contacts(config, customerUuid, { per_page: 10, cursor: 'aabbcc...' })
+ChartMogul.Customer.contacts(config, customerUuid, { per_page: 10, cursor: 'cursor==' })
 ChartMogul.Customer.createContact(config, customerUuid, data)
 ```
 
@@ -126,7 +123,7 @@ ChartMogul.Customer.createContact(config, customerUuid, data)
 
 ```js
 ChartMogul.Contact.create(config, data)
-ChartMogul.Contact.all(config, { per_page: 10, cursor: 'aabbcc...' })
+ChartMogul.Contact.all(config, { per_page: 10, cursor: 'cursor==' })
 ChartMogul.Contact.destroy(config, contactUuid)
 ```
 
@@ -135,10 +132,8 @@ ChartMogul.Contact.destroy(config, contactUuid)
 ```js
 ChartMogul.Plan.create(config, data)
 ChartMogul.Plan.retrieve(config, uuid)
-ChartMogul.Plan.modify(config, uuid, {
-    name: "new name"
-})
-ChartMogul.Plan.all(config, query)
+ChartMogul.Plan.modify(config, uuid, { name: "new name" })
+ChartMogul.Plan.all(config, { per_page: 10, cursor: 'cursor==' })
 ChartMogul.Plan.destroy(config, uuid)
 ```
 
@@ -148,7 +143,7 @@ ChartMogul.Plan.destroy(config, uuid)
 ChartMogul.PlanGroup.create(config, data)
 ChartMogul.PlanGroup.retrieve(config, planGroupUuid)
 ChartMogul.PlanGroup.modify(config, planGroupUuid, data)
-ChartMogul.PlanGroup.all(config, query)
+ChartMogul.PlanGroup.all(config, { per_page: 10, cursor: 'cursor==' })
 ChartMogul.PlanGroup.all(config, planGroupUuid, query)
 ChartMogul.PlanGroup.destroy(config, planGroupUuid)
 ```
@@ -158,7 +153,7 @@ ChartMogul.PlanGroup.destroy(config, planGroupUuid)
 ```js
 ChartMogul.Invoice.create(config, customerUuid, data)
 ChartMogul.Invoice.all(config, customerUuid, query)
-ChartMogul.Invoice.all(config, query)
+ChartMogul.Invoice.all(config, { per_page: 10, cursor: 'cursor==' })
 ChartMogul.Invoice.retrieve(config, invoiceUuid)
 ```
 

--- a/lib/chartmogul/errors/index.js
+++ b/lib/chartmogul/errors/index.js
@@ -6,6 +6,7 @@ const ForbiddenError = require('./forbidden-error');
 const NotFoundError = require('./not-found-error');
 const ResourceInvalidError = require('./resource-invalid-error');
 const SchemaInvalidError = require('./schema-invalid-error');
+const InvalidParameterError = require('./invalid-parameter-error');
 
 module.exports = {
   ChartMogulError,
@@ -13,5 +14,6 @@ module.exports = {
   ForbiddenError,
   NotFoundError,
   ResourceInvalidError,
-  SchemaInvalidError
+  SchemaInvalidError,
+  InvalidParameterError
 };

--- a/lib/chartmogul/errors/invalid-parameter-error.js
+++ b/lib/chartmogul/errors/invalid-parameter-error.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const ChartMogulError = require('./chartmogul-error');
+
+class InvalidParameterError extends ChartMogulError {
+  constructor (message, httpStatus, response) {
+    super(message, httpStatus, response);
+    Error.captureStackTrace(this, this.constructor.name);
+  }
+}
+
+module.exports = InvalidParameterError;

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -45,6 +45,13 @@ class Resource {
         return reject(error);
       }
 
+      if (method === 'GET' && data && data.page !== undefined) {
+        const error = new errors.InvalidParameterError(
+          "Argument 'per_page' is deprecated"
+        );
+        return reject(error);
+      }
+
       const qs = method === 'GET' ? data : {};
       const body = method === 'GET' ? {} : data;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "dependency-lint": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "dependency-lint": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/contact.js
+++ b/test/chartmogul/contact.js
@@ -71,7 +71,7 @@ describe('Contact', () => {
           customer_external_id: 'external_001',
           email: 'test@example.com'
         }],
-        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MDYxODYwMDArMDk6MDAmY29uXzAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMA==',
+        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MD==',
         has_more: false
       /* eslint-enable camelcase */
       });
@@ -80,8 +80,8 @@ describe('Contact', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
-        expect(res).to.have.property('cursor');
-        expect(res).to.have.property('has_more');
+        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+        expect(res.has_more).to.eql(false);
       });
   });
 

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -47,7 +47,7 @@ describe('Customer', () => {
       .get('/v1/customers')
       .reply(200, {
       /* eslint-disable camelcase */
-        customers: [{
+        entries: [{
           uuid: 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc',
           external_id: 'cus_0001',
           name: 'Adam Smith',
@@ -58,14 +58,18 @@ describe('Customer', () => {
           country: 'US',
           zip: '',
           data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-        }]
+        }],
+        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MD==',
+        has_more: false
       /* eslint-enable camelcase */
       });
 
     return Customer.all(config)
       .then(res => {
-        expect(res).to.have.property('customers');
-        expect(res.customers).to.be.instanceof(Array);
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -145,7 +149,7 @@ describe('Customer', () => {
           customer_external_id: 'external_001',
           email: 'test@example.com'
         }],
-        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MDYxODYwMDArMDk6MDAmY29uXzAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMA==',
+        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MD==',
         has_more: false
       /* eslint-enable camelcase */
       });
@@ -154,6 +158,8 @@ describe('Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+        expect(res.has_more).to.eql(false);
       });
   });
 });
@@ -208,8 +214,7 @@ describe('Enrichment#Customer', () => {
       /* eslint-disable camelcase */
         entries: [],
         has_more: false,
-        per_page: 200,
-        page: 1
+        cursor: 'JjI3MjI4NTM='
       /* eslint-enable camelcase */
       });
 
@@ -217,6 +222,8 @@ describe('Enrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('JjI3MjI4NTM=');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -232,8 +239,7 @@ describe('Enrichment#Customer', () => {
       /* eslint-disable camelcase */
         entries: [],
         has_more: false,
-        per_page: 200,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -243,6 +249,8 @@ describe('Enrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 

--- a/test/chartmogul/enrichment/customer.js
+++ b/test/chartmogul/enrichment/customer.js
@@ -55,8 +55,7 @@ describe('DeprecatedEnrichment#Customer', () => {
       /* eslint-disable camelcase */
         entries: [],
         has_more: false,
-        per_page: 200,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -64,6 +63,8 @@ describe('DeprecatedEnrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -79,8 +80,7 @@ describe('DeprecatedEnrichment#Customer', () => {
       /* eslint-disable camelcase */
         entries: [],
         has_more: false,
-        per_page: 200,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -90,6 +90,8 @@ describe('DeprecatedEnrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 

--- a/test/chartmogul/import/invoice.js
+++ b/test/chartmogul/import/invoice.js
@@ -116,8 +116,8 @@ describe('DeprecatedCustomerInvoice', () => {
       /* eslint-disable camelcase */
         customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
         invoices: [],
-        current_page: 1,
-        total_pages: 1
+        cursor: 'cursor==',
+        has_more: false
       /* eslint-enable camelcase */
       });
 
@@ -125,6 +125,8 @@ describe('DeprecatedCustomerInvoice', () => {
       .then(res => {
         expect(res).to.have.property('invoices');
         expect(res.invoices).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -137,8 +139,8 @@ describe('DeprecatedCustomerInvoice', () => {
       /* eslint-disable camelcase */
         customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
         invoices: [],
-        current_page: 1,
-        total_pages: 1
+        cursor: 'cursor==',
+        has_more: false
       /* eslint-enable camelcase */
       });
 
@@ -148,6 +150,8 @@ describe('DeprecatedCustomerInvoice', () => {
       }
       expect(res).to.have.property('invoices');
       expect(res.invoices).to.be.instanceof(Array);
+      expect(res.cursor).to.eql('cursor==');
+      expect(res.has_more).to.eql(false);
       done();
     });
   });

--- a/test/chartmogul/import/subscription.js
+++ b/test/chartmogul/import/subscription.js
@@ -80,8 +80,8 @@ describe('DeprecatedSubscription', () => {
           plan_uuid: 'pl_cff3a63c-3915-435e-a675-85a8a8ef4454',
           data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
         }],
-        current_page: 1,
-        total_pages: 1
+        cursor: 'cursor==',
+        has_more: true
       /* eslint-enable camelcase */
       });
 
@@ -89,6 +89,8 @@ describe('DeprecatedSubscription', () => {
       .then(res => {
         expect(res).to.have.property('subscriptions');
         expect(res.subscriptions).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(true);
       });
   });
 });

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -94,8 +94,8 @@ const newInvoiceListResult = {
       }
     ]
   }],
-  current_page: 1,
-  total_pages: 1
+  has_more: true,
+  cursor: 'cursor=='
 };
 /* eslint-enable camelcase */
 
@@ -162,8 +162,8 @@ describe('Customer Invoice', () => {
       /* eslint-disable camelcase */
         customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
         invoices: [],
-        current_page: 1,
-        total_pages: 1
+        has_more: false,
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -171,6 +171,8 @@ describe('Customer Invoice', () => {
       .then(res => {
         expect(res).to.have.property('invoices');
         expect(res.invoices).to.be.instanceof(Array);
+        expect(res.has_more).to.eql(false);
+        expect(res.cursor).to.eql('cursor==');
       });
   });
 
@@ -183,8 +185,8 @@ describe('Customer Invoice', () => {
       /* eslint-disable camelcase */
         customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
         invoices: [],
-        current_page: 1,
-        total_pages: 1
+        has_more: false,
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -194,6 +196,8 @@ describe('Customer Invoice', () => {
       }
       expect(res).to.have.property('invoices');
       expect(res.invoices).to.be.instanceof(Array);
+      expect(res.has_more).to.eql(false);
+      expect(res.cursor).to.eql('cursor==');
       done();
     });
   });
@@ -210,6 +214,8 @@ describe('Invoices', () => {
         expect(res).to.have.property('invoices');
         expect(res.invoices).to.be.instanceof(Array);
         expect(res.invoices[0].customer_uuid).to.equal('cus_9bf6482d-01e5-4944-957d-5bc730d2cda3');
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(true);
       });
   });
 
@@ -224,6 +230,8 @@ describe('Invoices', () => {
         expect(res).to.have.property('invoices');
         expect(res.invoices).to.be.instanceof(Array);
         expect(res.invoices[0].external_id).to.equal('INV0001');
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(true);
       });
   });
 

--- a/test/chartmogul/metrics/activity.js
+++ b/test/chartmogul/metrics/activity.js
@@ -35,12 +35,14 @@ describe('Activity', () => {
           }
         ],
         has_more: false,
-        per_page: 200
+        cursor: 'cursor=='
       });
     return Activity.all(config, query)
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.has_more).to.eql(false);
+        expect(res.cursor).to.eql('cursor==');
       });
   });
 });

--- a/test/chartmogul/metrics/index.js
+++ b/test/chartmogul/metrics/index.js
@@ -378,8 +378,7 @@ describe('Metrics', () => {
           'currency-sign': '$'
         }],
         has_more: false,
-        per_page: 200,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -387,6 +386,8 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -394,7 +395,7 @@ describe('Metrics', () => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     const query = {
-      page: 1,
+      cursor: 'cursor==',
       per_page: 10
     };
 
@@ -415,8 +416,7 @@ describe('Metrics', () => {
           'currency-sign': '$'
         }],
         has_more: false,
-        per_page: 10,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -424,6 +424,8 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -449,8 +451,7 @@ describe('Metrics', () => {
           'currency-sign': '$'
         }],
         has_more: false,
-        per_page: 200,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -458,6 +459,8 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -465,7 +468,7 @@ describe('Metrics', () => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     const query = {
-      page: 1,
+      cursor: 'cursor==',
       per_page: 25
     };
 
@@ -489,8 +492,7 @@ describe('Metrics', () => {
           'currency-sign': '$'
         }],
         has_more: false,
-        per_page: 25,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -498,6 +500,8 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 });

--- a/test/chartmogul/plan-group.js
+++ b/test/chartmogul/plan-group.js
@@ -61,9 +61,15 @@ describe('PlanGroup', () => {
       .get('/v1/plan_groups')
       .reply(200, {
       /* eslint-disable camelcase */
-        plan_groups: [],
-        current_page: 1,
-        total_pages: 0
+        plan_groups: [
+          {
+            name: 'All Plans',
+            uuid: 'plg_aa8c5eb3-a907-45da-bfa9-924f1a432d4a',
+            plans_count: 0
+          }
+        ],
+        cursor: 'MjAyMy0wNy0yN1Qx==',
+        has_more: true
       /* eslint-enable camelcase */
       });
 
@@ -71,6 +77,8 @@ describe('PlanGroup', () => {
       .then(res => {
         expect(res).to.have.property('plan_groups');
         expect(res.plan_groups).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('MjAyMy0wNy0yN1Qx==');
+        expect(res.has_more).to.eql(true);
       });
   });
 
@@ -98,8 +106,8 @@ describe('PlanGroup', () => {
             interval_unit: 'month',
             data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
           }],
-        current_page: 1,
-        total_pages: 0
+        cursor: 'MjAyMy0wNy0yN1Qx==',
+        has_more: false
       /* eslint-enable camelcase */
       });
 
@@ -111,6 +119,8 @@ describe('PlanGroup', () => {
       expect(res.plans).to.be.instanceof(Array);
       expect(res.plans[0].uuid).to.be.equal('pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462');
       expect(res.plans[1].uuid).to.be.equal('pl_eed05d54-75b4-431b-adb2-eb6b9e543206');
+      expect(res.cursor).to.eql('MjAyMy0wNy0yN1Qx==');
+      expect(res.has_more).to.eql(false);
     });
   });
 

--- a/test/chartmogul/plan.js
+++ b/test/chartmogul/plan.js
@@ -42,9 +42,18 @@ describe('Plan', () => {
       .get('/v1/plans')
       .reply(200, {
       /* eslint-disable camelcase */
-        plans: [],
-        current_page: 1,
-        total_pages: 0
+        plans: [
+          {
+            external_id: 'price_1NYSWgIFhx3XTAwSSnub7K43',
+            name: 'Test Product',
+            interval_count: 1,
+            uuid: 'pl_93756449-aaea-4662-9e3a-004e52f14adc',
+            interval_unit: 'month',
+            data_source_uuid: 'ds_d02c7c42-2d1d-11ee-8e58-3fa5919351b4'
+          }
+        ],
+        cursor: 'MjAyMy0wNy0yOFQwODowOT==',
+        has_more: true
       /* eslint-enable camelcase */
       });
 
@@ -52,6 +61,8 @@ describe('Plan', () => {
       .then(res => {
         expect(res).to.have.property('plans');
         expect(res.plans).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('MjAyMy0wNy0yOFQwODowOT==');
+        expect(res.has_more).to.eql(true);
       });
   });
 

--- a/test/chartmogul/resource.js
+++ b/test/chartmogul/resource.js
@@ -117,7 +117,7 @@ describe('Resource', () => {
     Customer.all(config, { page: 1 })
       .then(res => done(new Error('Should throw error')))
       .catch(e => {
-        expect(e).to.be.instanceOf(ChartMogul.ConfigurationError);
+        expect(e).to.be.instanceOf(ChartMogul.InvalidParameterError);
         done();
       });
   });

--- a/test/chartmogul/resource.js
+++ b/test/chartmogul/resource.js
@@ -10,6 +10,7 @@ const Customer = require('../../lib/chartmogul/customer');
 describe('Resource', () => {
   const config = new ChartMogul.Config('token');
   config.retries = 0; // no retry
+
   it('should send basicAuth headers', done => {
     nock(config.API_BASE)
       .get('/')
@@ -101,6 +102,19 @@ describe('Resource', () => {
 
   it('should throw ConfigurationError', done => {
     Customer.all()
+      .then(res => done(new Error('Should throw error')))
+      .catch(e => {
+        expect(e).to.be.instanceOf(ChartMogul.ConfigurationError);
+        done();
+      });
+  });
+
+  it('should throw InvalidParameterError', done => {
+    nock(config.API_BASE)
+      .get('/customers?page=1')
+      .reply(200, '{}');
+
+    Customer.all(config, { page: 1 })
       .then(res => done(new Error('Should throw error')))
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.ConfigurationError);

--- a/test/chartmogul/subscription-event.js
+++ b/test/chartmogul/subscription-event.js
@@ -34,24 +34,20 @@ describe('SubscriptionEvent', () => {
             retracted_event_id: null
           }
         ],
-        meta: {
-          next_key: 121,
-          prev_key: 123,
-          before_key: '2022-06-13T12:30:35.160Z',
-          page: 2,
-          total_pages: 121
-        }
+        has_more: false,
+        cursor: 'cursor=='
       });
 
     return SubscriptionEvent.all(config).then(res => {
       expect(res).to.have.property('subscription_events');
-      expect(res).to.have.property('meta');
       expect(res.subscription_events[0]).to.have.property('data_source_uuid');
       expect(res.subscription_events[0].data_source_uuid).to.eq('ds_e243129a-12c0-4e29-8f54-07da7905fbd1');
+      expect(res.cursor).to.eql('cursor==');
+      expect(res.has_more).to.eql(false);
     });
   });
 
-  it('should list create a subscription event', () => {
+  it('should create a subscription event', () => {
     const postBody = {
       subscription_event: {
         customer_external_id: 'c_ex_id_1',

--- a/test/chartmogul/subscription.js
+++ b/test/chartmogul/subscription.js
@@ -89,7 +89,7 @@ describe('Subscription', () => {
         expect(res).to.have.property('subscriptions');
         expect(res.subscriptions).to.be.instanceof(Array);
         expect(res.cursor).to.eql('cursor==');
-        expect(res.has_more).to.eql(false)
+        expect(res.has_more).to.eql(false);
       });
   });
 });

--- a/test/chartmogul/subscription.js
+++ b/test/chartmogul/subscription.js
@@ -79,8 +79,8 @@ describe('Subscription', () => {
           plan_uuid: 'pl_cff3a63c-3915-435e-a675-85a8a8ef4454',
           data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
         }],
-        current_page: 1,
-        total_pages: 1
+        has_more: false,
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -88,6 +88,8 @@ describe('Subscription', () => {
       .then(res => {
         expect(res).to.have.property('subscriptions');
         expect(res.subscriptions).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false)
       });
   });
 });


### PR DESCRIPTION
Since we added cursor based pagination to several of our API's endpoints this ensures the library supports that pagination. No need for code changes, but updated tests so we can ensure there is no regressions.