### PR TITLE
add support for cursor pagination to supported endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog],
+and this project adheres to [Semantic Versioning].
+
+[Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
+[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+
+## [2.1.2] - 2023-10-05
+
+### Added
+- Support for cursor based pagination to `.all()` endpoints.

--- a/README.md
+++ b/README.md
@@ -112,10 +112,7 @@ ChartMogul.DataSource.destroy(config, dataSourceUuid)
 
 ```js
 ChartMogul.Customer.create(config, data)
-ChartMogul.Customer.all(config, {
-  page: 2,
-  per_page: 20
-})
+ChartMogul.Customer.all(config, { per_page: 20 })
 ChartMogul.Customer.destroy(config, customerUuid)
 
 ChartMogul.Customer.contacts(config, customerUuid, { per_page: 10, cursor: 'aabbcc...' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "dependency-lint": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/contact.js
+++ b/test/chartmogul/contact.js
@@ -71,7 +71,7 @@ describe('Contact', () => {
           customer_external_id: 'external_001',
           email: 'test@example.com'
         }],
-        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MDYxODYwMDArMDk6MDAmY29uXzAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMA==',
+        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MD==',
         has_more: false
       /* eslint-enable camelcase */
       });
@@ -80,8 +80,8 @@ describe('Contact', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
-        expect(res).to.have.property('cursor');
-        expect(res).to.have.property('has_more');
+        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+        expect(res.has_more).to.eql(false);
       });
   });
 

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -42,12 +42,12 @@ describe('Customer', () => {
       });
   });
 
-  it('should get all customers', () => {
+  it('should get all customers with old pagination', () => {
     nock(config.API_BASE)
       .get('/v1/customers')
       .reply(200, {
       /* eslint-disable camelcase */
-        customers: [{
+        entries: [{
           uuid: 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc',
           external_id: 'cus_0001',
           name: 'Adam Smith',
@@ -58,14 +58,50 @@ describe('Customer', () => {
           country: 'US',
           zip: '',
           data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-        }]
+        }],
+        current_page: 1,
+        total_pages: 1,
+        page: 1
       /* eslint-enable camelcase */
       });
 
     return Customer.all(config)
       .then(res => {
-        expect(res).to.have.property('customers');
-        expect(res.customers).to.be.instanceof(Array);
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
+        expect(res.total_pages).to.eql(1);
+      });
+  });
+
+  it('should get all customers with new pagination', () => {
+    nock(config.API_BASE)
+      .get('/v1/customers')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [{
+          uuid: 'cus_7e4e5c3d-832c-4fa4-bf77-6fdc8c6e14bc',
+          external_id: 'cus_0001',
+          name: 'Adam Smith',
+          company: '',
+          email: 'adam@smith.com',
+          city: 'New York',
+          state: '',
+          country: 'US',
+          zip: '',
+          data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+        }],
+        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MD==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    return Customer.all(config)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+        expect(res.has_more).to.eql(false);
       });
   });
 
@@ -145,7 +181,7 @@ describe('Customer', () => {
           customer_external_id: 'external_001',
           email: 'test@example.com'
         }],
-        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MDYxODYwMDArMDk6MDAmY29uXzAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMA==',
+        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MD==',
         has_more: false
       /* eslint-enable camelcase */
       });
@@ -154,6 +190,8 @@ describe('Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+        expect(res.has_more).to.eql(false);
       });
   });
 });
@@ -201,7 +239,7 @@ describe('Enrichment#Customer', () => {
       });
   });
 
-  it('should get all customers', () => {
+  it('should get all customers with old pagination', () => {
     nock(config.API_BASE)
       .get('/v1/customers')
       .reply(200, {
@@ -217,10 +255,31 @@ describe('Enrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
       });
   });
 
-  it('should search for a customer', () => {
+  it('should get all customers with new pagination', () => {
+    nock(config.API_BASE)
+      .get('/v1/customers')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [],
+        has_more: false,
+        cursor: null
+      /* eslint-enable camelcase */
+      });
+
+    return Customer.all(config)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql(null);
+        expect(res.has_more).to.eql(false);
+      });
+  });
+
+  it('should search for a customer with old pagination', () => {
     const email = 'adam@smith.com';
 
     nock(config.API_BASE)
@@ -243,6 +302,34 @@ describe('Enrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
+      });
+  });
+
+  it('should search for a customer with new pagination', () => {
+    const email = 'adam@smith.com';
+
+    nock(config.API_BASE)
+      .get('/v1/customers/search')
+      .query({
+        email
+      })
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [],
+        has_more: false,
+        cursor: 'JjI3MjI4NTM=='
+      /* eslint-enable camelcase */
+      });
+
+    return Customer.search(config, {
+      email
+    })
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('JjI3MjI4NTM==');
+        expect(res.has_more).to.eql(false);
       });
   });
 

--- a/test/chartmogul/enrichment/customer.js
+++ b/test/chartmogul/enrichment/customer.js
@@ -48,7 +48,7 @@ describe('DeprecatedEnrichment#Customer', () => {
       });
   });
 
-  it('should get all customers', () => {
+  it('should get all customers with old pagination', () => {
     nock(config.API_BASE)
       .get('/v1/customers')
       .reply(200, {
@@ -64,10 +64,31 @@ describe('DeprecatedEnrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
       });
   });
 
-  it('should search for a customer', () => {
+  it('should get all customers with new pagination', () => {
+    nock(config.API_BASE)
+      .get('/v1/customers')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [],
+        has_more: false,
+        cursor: 'cursor=='
+      /* eslint-enable camelcase */
+      });
+
+    return Customer.all(config)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
+      });
+  });
+
+  it('should search for a customer with old pagination', () => {
     const email = 'adam@smith.com';
 
     nock(config.API_BASE)
@@ -90,6 +111,34 @@ describe('DeprecatedEnrichment#Customer', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
+      });
+  });
+
+  it('should search for a customer with new pagination', () => {
+    const email = 'adam@smith.com';
+
+    nock(config.API_BASE)
+      .get('/v1/customers/search')
+      .query({
+        email
+      })
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [],
+        has_more: false,
+        cursor: 'cursor=='
+      /* eslint-enable camelcase */
+      });
+
+    return Customer.search(config, {
+      email
+    })
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 

--- a/test/chartmogul/import/invoice.js
+++ b/test/chartmogul/import/invoice.js
@@ -107,7 +107,7 @@ describe('DeprecatedCustomerInvoice', () => {
     });
   });
 
-  it('should get all customer invoices', () => {
+  it('should get all customer invoices with old pagination', () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -125,10 +125,35 @@ describe('DeprecatedCustomerInvoice', () => {
       .then(res => {
         expect(res).to.have.property('invoices');
         expect(res.invoices).to.be.instanceof(Array);
+        expect(res.current_page).to.eql(1);
+        expect(res.total_pages).to.eql(1);
       });
   });
 
-  it('should get all customer invoices in a callback', done => {
+  it('should get all customer invoices with new pagination', () => {
+    const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    nock(config.API_BASE)
+      .get('/v1/import/customers/' + customerUUID + '/invoices')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
+        invoices: [],
+        cursor: 'cursor==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    return Invoice.all(config, customerUUID)
+      .then(res => {
+        expect(res).to.have.property('invoices');
+        expect(res.invoices).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
+      });
+  });
+
+  it('should get all customer invoices in callback (old pagination)', done => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -148,6 +173,34 @@ describe('DeprecatedCustomerInvoice', () => {
       }
       expect(res).to.have.property('invoices');
       expect(res.invoices).to.be.instanceof(Array);
+      expect(res.current_page).to.eql(1);
+      expect(res.total_pages).to.eql(1);
+      done();
+    });
+  });
+
+  it('should get all customer invoices in callback (new pagination)', done => {
+    const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    nock(config.API_BASE)
+      .get('/v1/import/customers/' + customerUUID + '/invoices')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
+        invoices: [],
+        cursor: 'cursor==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    Invoice.all(config, customerUUID, (err, res) => {
+      if (err) {
+        return done(err);
+      }
+      expect(res).to.have.property('invoices');
+      expect(res.invoices).to.be.instanceof(Array);
+      expect(res.cursor).to.eql('cursor==');
+      expect(res.has_more).to.eql(false);
       done();
     });
   });

--- a/test/chartmogul/import/subscription.js
+++ b/test/chartmogul/import/subscription.js
@@ -65,7 +65,7 @@ describe('DeprecatedSubscription', () => {
       });
   });
 
-  it('should get all subscriptions', () => {
+  it('should get all subscriptions with old pagination', () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -89,6 +89,37 @@ describe('DeprecatedSubscription', () => {
       .then(res => {
         expect(res).to.have.property('subscriptions');
         expect(res.subscriptions).to.be.instanceof(Array);
+        expect(res.current_page).to.eql(1);
+        expect(res.total_pages).to.eql(1);
+      });
+  });
+
+  it('should get all subscriptions with new pagination', () => {
+    const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    nock(config.API_BASE)
+      .get('/v1/import/customers/' + customerUUID + '/subscriptions')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
+        subscriptions: [{
+          uuid: 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88',
+          external_id: 'sub_0001',
+          cancellation_dates: [],
+          plan_uuid: 'pl_cff3a63c-3915-435e-a675-85a8a8ef4454',
+          data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+        }],
+        cursor: 'cursor==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    return Subscription.all(config, customerUUID)
+      .then(res => {
+        expect(res).to.have.property('subscriptions');
+        expect(res.subscriptions).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 });

--- a/test/chartmogul/metrics/activity.js
+++ b/test/chartmogul/metrics/activity.js
@@ -7,7 +7,7 @@ const nock = require('nock');
 const Activity = ChartMogul.Metrics.Activity;
 
 describe('Activity', () => {
-  it('should retrieve all activities', () => {
+  it('should retrieve all activities with old pagination', () => {
     const query = {
       'start-date': '2020-01-01'
     };
@@ -41,6 +41,47 @@ describe('Activity', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.has_more).to.eql(false);
+        expect(res.per_page).to.eql(200);
+      });
+  });
+
+  it('should retrieve all activities with new pagination', () => {
+    const query = {
+      'start-date': '2020-01-01'
+    };
+
+    nock(config.API_BASE)
+      .get('/v1/activities')
+      .query(query)
+      .reply(200, {
+        entries: [
+          {
+            description: 'purchased the plan_11 plan',
+            'activity-mrr-movement': 6000,
+            'activity-mrr': 6000,
+            'activity-arr': 72000,
+            date: '2020-05-06T01:00:00',
+            type: 'new_biz',
+            currency: 'USD',
+            'subscription-external-id': 'sub_2',
+            'plan-external-id': '11',
+            'customer-name': 'customer_2',
+            'customer-uuid': '8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7',
+            'customer-external-id': 'customer_2',
+            'billing-connector-uuid': '99076cb8-97a1-11eb-8798-a73b507e7929',
+            uuid: 'f1a49735-21c7-4e3f-9ddc-67927aaadcf4'
+          }
+        ],
+        has_more: false,
+        cursor: 'cursor=='
+      });
+    return Activity.all(config, query)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.has_more).to.eql(false);
+        expect(res.cursor).to.eql('cursor==');
       });
   });
 });

--- a/test/chartmogul/metrics/index.js
+++ b/test/chartmogul/metrics/index.js
@@ -359,7 +359,7 @@ describe('Metrics', () => {
       });
   });
 
-  it('should list customer activites', () => {
+  it('should list customer activites with old pagination', () => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -387,6 +387,8 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
+        expect(res.per_page).to.eql(200);
       });
   });
 
@@ -424,10 +426,79 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
+        expect(res.per_page).to.eql(10);
       });
   });
 
-  it('should list customer subscriptions', () => {
+  it('should list customer activites with new pagination', () => {
+    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    nock(config.API_BASE)
+      .get(`/v1/customers/${customerUuid}/activities`)
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [{
+          id: 495366,
+          description: 'purchased the Bronze Plan plan with $10.00 discount applied',
+          'activity-mrr-movement': 4100,
+          'activity-mrr': 4100,
+          'activity-arr': 49200,
+          date: '2015-11-01T00:00:00+00:00',
+          type: 'new_biz',
+          currency: 'USD',
+          'currency-sign': '$'
+        }],
+        has_more: false,
+        cursor: 'cursor=='
+      /* eslint-enable camelcase */
+      });
+
+    return Metrics.Customer.activities(config, customerUuid)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.has_more).to.eql(false);
+        expect(res.cursor).to.eql('cursor==');
+      });
+  });
+
+  it('should list customer activites cursored', () => {
+    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    const query = { cursor: 'cursor==' };
+
+    nock(config.API_BASE)
+      .get(`/v1/customers/${customerUuid}/activities`)
+      .query(query)
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [{
+          id: 495366,
+          description: 'purchased the Bronze Plan plan with $10.00 discount applied',
+          'activity-mrr-movement': 4100,
+          'activity-mrr': 4100,
+          'activity-arr': 49200,
+          date: '2015-11-01T00:00:00+00:00',
+          type: 'new_biz',
+          currency: 'USD',
+          'currency-sign': '$'
+        }],
+        has_more: false,
+        cursor: null
+      /* eslint-enable camelcase */
+      });
+
+    return Metrics.Customer.activities(config, customerUuid, query)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.cursor).to.eql(null);
+        expect(res.has_more).to.eql(false);
+      });
+  });
+
+  it('should list customer subscriptions with old pagination', () => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -458,6 +529,8 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.page).to.eql(1);
+        expect(res.per_page).to.eql(200);
       });
   });
 
@@ -498,6 +571,81 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
+        expect(res.per_page).to.eql(25);
+        expect(res.page).to.eql(1);
+      });
+  });
+
+  it('should list customer subscriptions with new pagination', () => {
+    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    nock(config.API_BASE)
+      .get(`/v1/customers/${customerUuid}/subscriptions`)
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [{
+          id: 297047,
+          plan: 'Bronze Plan',
+          quantity: 0,
+          mrr: 0,
+          arr: 0,
+          status: 'inactive',
+          'billing-cycle': 'month',
+          'billing-cycle-count': 1,
+          'start-date': '2016-01-15T00:00:00+00:00',
+          'end-date': '2016-01-15T00:00:00+00:00',
+          currency: 'USD',
+          'currency-sign': '$'
+        }],
+        has_more: false,
+        cursor: 'cursor=='
+      /* eslint-enable camelcase */
+      });
+
+    return Metrics.Customer.subscriptions(config, customerUuid)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.has_more).to.eql(false);
+        expect(res.cursor).to.eql('cursor==');
+      });
+  });
+
+  it('should list customer subscriptions cursored', () => {
+    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    const query = { cursor: 'cursor==' };
+
+    nock(config.API_BASE)
+      .get(`/v1/customers/${customerUuid}/subscriptions`)
+      .query(query)
+      .reply(200, {
+      /* eslint-disable camelcase */
+        entries: [{
+          id: 297047,
+          plan: 'Bronze Plan',
+          quantity: 0,
+          mrr: 0,
+          arr: 0,
+          status: 'inactive',
+          'billing-cycle': 'month',
+          'billing-cycle-count': 1,
+          'start-date': '2016-01-15T00:00:00+00:00',
+          'end-date': '2016-01-15T00:00:00+00:00',
+          currency: 'USD',
+          'currency-sign': '$'
+        }],
+        has_more: false,
+        cursor: 'cursor=='
+      /* eslint-enable camelcase */
+      });
+
+    return Metrics.Customer.subscriptions(config, customerUuid, query)
+      .then(res => {
+        expect(res).to.have.property('entries');
+        expect(res.entries).to.be.instanceof(Array);
+        expect(res.has_more).to.eql(false);
+        expect(res.cursor).to.eql('cursor==');
       });
   });
 });

--- a/test/chartmogul/plan-group.js
+++ b/test/chartmogul/plan-group.js
@@ -56,7 +56,7 @@ describe('PlanGroup', () => {
     });
   });
 
-  it('should get all plan groups', () => {
+  it('should get all plan groups with old pagination', () => {
     nock(config.API_BASE)
       .get('/v1/plan_groups')
       .reply(200, {
@@ -71,10 +71,32 @@ describe('PlanGroup', () => {
       .then(res => {
         expect(res).to.have.property('plan_groups');
         expect(res.plan_groups).to.be.instanceof(Array);
+        expect(res.current_page).to.eql(1);
+        expect(res.total_pages).to.eql(0);
       });
   });
 
-  it('should get all plans for a plan group', () => {
+  it('should get all plan groups with new pagination', () => {
+    nock(config.API_BASE)
+      .get('/v1/plan_groups')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        plan_groups: [],
+        cursor: 'cursor==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    return PlanGroup.all(config)
+      .then(res => {
+        expect(res).to.have.property('plan_groups');
+        expect(res.plan_groups).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
+      });
+  });
+
+  it('should get all plans for a plan group with old pagination', () => {
     const planGroupUUID = 'plg_eed05d54-75b4-431b-adb2-eb6b9e543206';
 
     nock(config.API_BASE)
@@ -111,6 +133,50 @@ describe('PlanGroup', () => {
       expect(res.plans).to.be.instanceof(Array);
       expect(res.plans[0].uuid).to.be.equal('pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462');
       expect(res.plans[1].uuid).to.be.equal('pl_eed05d54-75b4-431b-adb2-eb6b9e543206');
+      expect(res.current_page).to.eql(1);
+      expect(res.total_pages).to.eql(0);
+    });
+  });
+
+  it('should get all plans for a plan group with new pagination', () => {
+    const planGroupUUID = 'plg_eed05d54-75b4-431b-adb2-eb6b9e543206';
+
+    nock(config.API_BASE)
+      .get('/v1/plan_groups/' + planGroupUUID + '/plans')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        plans: [
+          {
+            uuid: 'pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462',
+            external_id: 'plan_0001',
+            name: 'Bronze Plan',
+            interval_count: 1,
+            interval_unit: 'month',
+            data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+          },
+          {
+            uuid: 'pl_eed05d54-75b4-431b-adb2-eb6b9e543206',
+            external_id: 'plan_0001',
+            name: 'Bronze Plan',
+            interval_count: 1,
+            interval_unit: 'month',
+            data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+          }],
+        cursor: 'cursor==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    return PlanGroup.all(config, planGroupUUID, (err, res) => {
+      if (err) {
+        return err;
+      }
+      expect(res).to.have.property('plans');
+      expect(res.plans).to.be.instanceof(Array);
+      expect(res.plans[0].uuid).to.be.equal('pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462');
+      expect(res.plans[1].uuid).to.be.equal('pl_eed05d54-75b4-431b-adb2-eb6b9e543206');
+      expect(res.cursor).to.eql('cursor==');
+      expect(res.has_more).to.eql(false);
     });
   });
 

--- a/test/chartmogul/plan.js
+++ b/test/chartmogul/plan.js
@@ -37,7 +37,7 @@ describe('Plan', () => {
       });
   });
 
-  it('should get all plans', () => {
+  it('should get all plans with old pagination', () => {
     nock(config.API_BASE)
       .get('/v1/plans')
       .reply(200, {
@@ -52,6 +52,28 @@ describe('Plan', () => {
       .then(res => {
         expect(res).to.have.property('plans');
         expect(res.plans).to.be.instanceof(Array);
+        expect(res.current_page).to.eql(1);
+        expect(res.total_pages).to.eql(0);
+      });
+  });
+
+  it('should get all plans with new pagination', () => {
+    nock(config.API_BASE)
+      .get('/v1/plans')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        plans: [],
+        cursor: 'cursor==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    return Plan.all(config)
+      .then(res => {
+        expect(res).to.have.property('plans');
+        expect(res.plans).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 

--- a/test/chartmogul/resource.js
+++ b/test/chartmogul/resource.js
@@ -10,6 +10,7 @@ const Customer = require('../../lib/chartmogul/customer');
 describe('Resource', () => {
   const config = new ChartMogul.Config('token');
   config.retries = 0; // no retry
+
   it('should send basicAuth headers', done => {
     nock(config.API_BASE)
       .get('/')

--- a/test/chartmogul/subscription-event.js
+++ b/test/chartmogul/subscription-event.js
@@ -8,7 +8,7 @@ const SubscriptionEvent = ChartMogul.SubscriptionEvent;
 const path = '/v1/subscription_events';
 
 describe('SubscriptionEvent', () => {
-  it('should list all subscription events', () => {
+  it('should list all subscription events with old pagination', () => {
     nock(config.API_BASE)
       .get(path)
       .reply(200, {
@@ -48,10 +48,52 @@ describe('SubscriptionEvent', () => {
       expect(res).to.have.property('meta');
       expect(res.subscription_events[0]).to.have.property('data_source_uuid');
       expect(res.subscription_events[0].data_source_uuid).to.eq('ds_e243129a-12c0-4e29-8f54-07da7905fbd1');
+      expect(res.meta.total_pages).to.eql(121);
+      expect(res.meta.before_key).to.eql('2022-06-13T12:30:35.160Z');
     });
   });
 
-  it('should list create a subscription event', () => {
+  it('should list all subscription events with new pagination', () => {
+    nock(config.API_BASE)
+      .get(path)
+      .reply(200, {
+        subscription_events: [
+          {
+            id: 101,
+            data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
+            customer_external_id: '39530',
+            subscription_set_external_id: null,
+            subscription_external_id: 'subscription_39530',
+            plan_external_id: 'gazillion_monthly',
+            event_date: '2022-06-01T00:00:00Z',
+            effective_date: '2022-06-02T00:00:00Z',
+            event_type: 'subscription_cancelled',
+            external_id: 'ex_id_1',
+            errors: {},
+            created_at: '2022-06-13T11:06:56Z',
+            updated_at: '2022-06-13T12:19:40Z',
+            quantity: null,
+            currency: null,
+            amount_in_cents: null,
+            tax_amount_in_cents: null,
+            retracted_event_id: null
+          }
+        ],
+        cursor: 'cursor==',
+        has_more: true
+      });
+
+    return SubscriptionEvent.all(config).then(res => {
+      expect(res).to.have.property('subscription_events');
+      expect(res).to.not.have.property('meta');
+      expect(res.subscription_events[0]).to.have.property('data_source_uuid');
+      expect(res.subscription_events[0].data_source_uuid).to.eq('ds_e243129a-12c0-4e29-8f54-07da7905fbd1');
+      expect(res.cursor).to.eql('cursor==');
+      expect(res.has_more).to.eql(true);
+    });
+  });
+
+  it('should create a subscription event', () => {
     const postBody = {
       subscription_event: {
         customer_external_id: 'c_ex_id_1',

--- a/test/chartmogul/subscription.js
+++ b/test/chartmogul/subscription.js
@@ -64,7 +64,7 @@ describe('Subscription', () => {
       });
   });
 
-  it('should get all subscriptions', () => {
+  it('should get all subscriptions with old pagination', () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -88,6 +88,37 @@ describe('Subscription', () => {
       .then(res => {
         expect(res).to.have.property('subscriptions');
         expect(res.subscriptions).to.be.instanceof(Array);
+        expect(res.current_page).to.eql(1);
+        expect(res.total_pages).to.eql(1);
+      });
+  });
+
+  it('should get all subscriptions with new pagination', () => {
+    const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+
+    nock(config.API_BASE)
+      .get('/v1/import/customers/' + customerUUID + '/subscriptions')
+      .reply(200, {
+      /* eslint-disable camelcase */
+        customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
+        subscriptions: [{
+          uuid: 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88',
+          external_id: 'sub_0001',
+          cancellation_dates: [],
+          plan_uuid: 'pl_cff3a63c-3915-435e-a675-85a8a8ef4454',
+          data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+        }],
+        cursor: 'cursor==',
+        has_more: false
+      /* eslint-enable camelcase */
+      });
+
+    return Subscription.all(config, customerUUID)
+      .then(res => {
+        expect(res).to.have.property('subscriptions');
+        expect(res.subscriptions).to.be.instanceof(Array);
+        expect(res.cursor).to.eql('cursor==');
+        expect(res.has_more).to.eql(false);
       });
   });
 });


### PR DESCRIPTION
## Changelog

- Support cursor based pagination
- Add a Changelog

We will release soon a major version ([PR is here](https://github.com/chartmogul/chartmogul-node/pull/80)) that deprecates the old pagination, but we want to ensure the current version will work with both paginations in tandem in case of a server regression that can lead to broken clients out there.