### PR TITLE
deprecate `page` query param, drop support for node 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [16, 18, 20, '*']
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18, '*']
+        node-version: [16, 18, 20]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [3.0.0] - 2023-11-01
+
+### Removed
+- Remove support for old pagination using `page` parameter.
+- Remove support for Node v14.x.
+
 ## [2.1.2] - 2023-10-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Installation
 
-This library requires node.js 14.x or above.
+This library requires node.js 16.x or above.
 
 ```sh
 npm install --save chartmogul-node
@@ -331,6 +331,7 @@ The library throws following error objects.
 - `ChartMogul.NotFoundError`
 - `ChartMogul.ResourceInvalidError`
 - `ChartMogul.SchemaInvalidError`
+- `ChartMogul.DeprecatedParamError`
 
 The following table describes the properties of the error object.
 

--- a/lib/chartmogul/errors/deprecated-param-error.js
+++ b/lib/chartmogul/errors/deprecated-param-error.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const ChartMogulError = require('./chartmogul-error');
+
+class DeprecatedParamError extends ChartMogulError {
+  constructor (message, httpStatus, response) {
+    super(message, httpStatus, response);
+    Error.captureStackTrace(this, this.constructor.name);
+  }
+}
+
+module.exports = DeprecatedParamError;

--- a/lib/chartmogul/errors/index.js
+++ b/lib/chartmogul/errors/index.js
@@ -6,6 +6,7 @@ const ForbiddenError = require('./forbidden-error');
 const NotFoundError = require('./not-found-error');
 const ResourceInvalidError = require('./resource-invalid-error');
 const SchemaInvalidError = require('./schema-invalid-error');
+const DeprecatedParamError = require('./deprecated-param-error');
 
 module.exports = {
   ChartMogulError,
@@ -13,5 +14,6 @@ module.exports = {
   ForbiddenError,
   NotFoundError,
   ResourceInvalidError,
-  SchemaInvalidError
+  SchemaInvalidError,
+  DeprecatedParamError
 };

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -45,6 +45,13 @@ class Resource {
         return reject(error);
       }
 
+      if (data && data.page) {
+        const error = new errors.DeprecatedParamError(
+          '"page" param is deprecated', 422, {}
+        );
+        return reject(error);
+      }
+
       const qs = method === 'GET' ? data : {};
       const body = method === 'GET' ? {} : data;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "2.1.2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "dependency-lint": "^7.1.0",
@@ -28,7 +28,7 @@
         "pre-commit": ""
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/chartmogul/chartmogul-node",
   "engines": {
-    "node": ">=4"
+    "node": ">=16"
   },
   "dependencies": {
     "dependency-lint": "^7.1.0",

--- a/test/chartmogul/enrichment/customer.js
+++ b/test/chartmogul/enrichment/customer.js
@@ -48,27 +48,26 @@ describe('DeprecatedEnrichment#Customer', () => {
       });
   });
 
-  it('should get all customers with old pagination', () => {
+  it('throws DeprecatedParamError if using old pagination parameter', done => {
+    const query = {
+      page: 1
+    };
+
     nock(config.API_BASE)
       .get('/v1/customers')
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [],
-        has_more: false,
-        per_page: 200,
-        page: 1
-      /* eslint-enable camelcase */
-      });
-
-    return Customer.all(config)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.page).to.eql(1);
+      .query(query)
+      .reply(200, {});
+    Customer.all(config, query)
+      .then(res => done(new Error('Should throw error')))
+      .catch(e => {
+        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
+        expect(e.httpStatus).to.equal(422);
+        expect(e.message).to.equal('"page" param is deprecated {}');
+        done();
       });
   });
 
-  it('should get all customers with new pagination', () => {
+  it('should get all customers with pagination', () => {
     nock(config.API_BASE)
       .get('/v1/customers')
       .reply(200, {
@@ -88,41 +87,16 @@ describe('DeprecatedEnrichment#Customer', () => {
       });
   });
 
-  it('should search for a customer with old pagination', () => {
+  it('should search for a customer with pagination', () => {
     const email = 'adam@smith.com';
+    const query = {
+      email,
+      per_page: 1
+    };
 
     nock(config.API_BASE)
       .get('/v1/customers/search')
-      .query({
-        email
-      })
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [],
-        has_more: false,
-        per_page: 200,
-        page: 1
-      /* eslint-enable camelcase */
-      });
-
-    return Customer.search(config, {
-      email
-    })
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.page).to.eql(1);
-      });
-  });
-
-  it('should search for a customer with new pagination', () => {
-    const email = 'adam@smith.com';
-
-    nock(config.API_BASE)
-      .get('/v1/customers/search')
-      .query({
-        email
-      })
+      .query(query)
       .reply(200, {
       /* eslint-disable camelcase */
         entries: [],
@@ -131,9 +105,7 @@ describe('DeprecatedEnrichment#Customer', () => {
       /* eslint-enable camelcase */
       });
 
-    return Customer.search(config, {
-      email
-    })
+    return Customer.search(config, query)
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);

--- a/test/chartmogul/metrics/activity.js
+++ b/test/chartmogul/metrics/activity.js
@@ -7,48 +7,31 @@ const nock = require('nock');
 const Activity = ChartMogul.Metrics.Activity;
 
 describe('Activity', () => {
-  it('should retrieve all activities with old pagination', () => {
+  it('throws DeprecatedParamError if using old pagination parameter', done => {
     const query = {
-      'start-date': '2020-01-01'
+      'start-date': '2020-01-01',
+      page: 1
     };
 
     nock(config.API_BASE)
       .get('/v1/activities')
       .query(query)
-      .reply(200, {
-        entries: [
-          {
-            description: 'purchased the plan_11 plan',
-            'activity-mrr-movement': 6000,
-            'activity-mrr': 6000,
-            'activity-arr': 72000,
-            date: '2020-05-06T01:00:00',
-            type: 'new_biz',
-            currency: 'USD',
-            'subscription-external-id': 'sub_2',
-            'plan-external-id': '11',
-            'customer-name': 'customer_2',
-            'customer-uuid': '8bc55ab6-c3b5-11eb-ac45-2f9a49d75af7',
-            'customer-external-id': 'customer_2',
-            'billing-connector-uuid': '99076cb8-97a1-11eb-8798-a73b507e7929',
-            uuid: 'f1a49735-21c7-4e3f-9ddc-67927aaadcf4'
-          }
-        ],
-        has_more: false,
-        per_page: 200
-      });
-    return Activity.all(config, query)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.has_more).to.eql(false);
-        expect(res.per_page).to.eql(200);
+      .reply(200, {});
+    Activity.all(config, query)
+      .then(res => done(new Error('Should throw error')))
+      .catch(e => {
+        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
+        expect(e.httpStatus).to.equal(422);
+        expect(e.message).to.equal('"page" param is deprecated {}');
+        done();
       });
   });
 
-  it('should retrieve all activities with new pagination', () => {
+  it('should retrieve all activities with pagination', () => {
     const query = {
-      'start-date': '2020-01-01'
+      'start-date': '2020-01-01',
+      per_page: 1,
+      cursor: 'cursor=='
     };
 
     nock(config.API_BASE)

--- a/test/chartmogul/metrics/index.js
+++ b/test/chartmogul/metrics/index.js
@@ -359,42 +359,8 @@ describe('Metrics', () => {
       });
   });
 
-  it('should list customer activites with old pagination', () => {
+  it('throws DeprecatedParamError if using old pagination parameter', done => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
-
-    nock(config.API_BASE)
-      .get(`/v1/customers/${customerUuid}/activities`)
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [{
-          id: 495366,
-          description: 'purchased the Bronze Plan plan with $10.00 discount applied',
-          'activity-mrr-movement': 4100,
-          'activity-mrr': 4100,
-          'activity-arr': 49200,
-          date: '2015-11-01T00:00:00+00:00',
-          type: 'new_biz',
-          currency: 'USD',
-          'currency-sign': '$'
-        }],
-        has_more: false,
-        per_page: 200,
-        page: 1
-      /* eslint-enable camelcase */
-      });
-
-    return Metrics.Customer.activities(config, customerUuid)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.page).to.eql(1);
-        expect(res.per_page).to.eql(200);
-      });
-  });
-
-  it('should list customer activites paged', () => {
-    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
-
     const query = {
       page: 1,
       per_page: 10
@@ -403,69 +369,19 @@ describe('Metrics', () => {
     nock(config.API_BASE)
       .get(`/v1/customers/${customerUuid}/activities`)
       .query(query)
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [{
-          id: 495366,
-          description: 'purchased the Bronze Plan plan with $10.00 discount applied',
-          'activity-mrr-movement': 4100,
-          'activity-mrr': 4100,
-          'activity-arr': 49200,
-          date: '2015-11-01T00:00:00+00:00',
-          type: 'new_biz',
-          currency: 'USD',
-          'currency-sign': '$'
-        }],
-        has_more: false,
-        per_page: 10,
-        page: 1
-      /* eslint-enable camelcase */
-      });
-
-    return Metrics.Customer.activities(config, customerUuid, query)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.page).to.eql(1);
-        expect(res.per_page).to.eql(10);
+      .reply(200, {});
+    Metrics.Customer.activities(config, customerUuid, query)
+      .then(res => done(new Error('Should throw error')))
+      .catch(e => {
+        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
+        expect(e.httpStatus).to.equal(422);
+        expect(e.message).to.equal('"page" param is deprecated {}');
+        done();
       });
   });
 
-  it('should list customer activites with new pagination', () => {
+  it('should list customer activites with pagination', () => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
-
-    nock(config.API_BASE)
-      .get(`/v1/customers/${customerUuid}/activities`)
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [{
-          id: 495366,
-          description: 'purchased the Bronze Plan plan with $10.00 discount applied',
-          'activity-mrr-movement': 4100,
-          'activity-mrr': 4100,
-          'activity-arr': 49200,
-          date: '2015-11-01T00:00:00+00:00',
-          type: 'new_biz',
-          currency: 'USD',
-          'currency-sign': '$'
-        }],
-        has_more: false,
-        cursor: 'cursor=='
-      /* eslint-enable camelcase */
-      });
-
-    return Metrics.Customer.activities(config, customerUuid)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.has_more).to.eql(false);
-        expect(res.cursor).to.eql('cursor==');
-      });
-  });
-
-  it('should list customer activites cursored', () => {
-    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
-
     const query = { cursor: 'cursor==' };
 
     nock(config.API_BASE)
@@ -485,7 +401,7 @@ describe('Metrics', () => {
           'currency-sign': '$'
         }],
         has_more: false,
-        cursor: null
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
@@ -493,16 +409,18 @@ describe('Metrics', () => {
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
-        expect(res.cursor).to.eql(null);
         expect(res.has_more).to.eql(false);
+        expect(res.cursor).to.eql('cursor==');
       });
   });
 
-  it('should list customer subscriptions with old pagination', () => {
+  it('should list customer subscriptions with pagination', () => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+    const query = { cursor: 'cursor==', per_page: 200 };
 
     nock(config.API_BASE)
       .get(`/v1/customers/${customerUuid}/subscriptions`)
+      .query(query)
       .reply(200, {
       /* eslint-disable camelcase */
         entries: [{
@@ -521,131 +439,16 @@ describe('Metrics', () => {
         }],
         has_more: false,
         per_page: 200,
-        page: 1
+        cursor: 'cursor=='
       /* eslint-enable camelcase */
       });
 
-    return Metrics.Customer.subscriptions(config, customerUuid)
+    return Metrics.Customer.subscriptions(config, customerUuid, query)
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
-        expect(res.page).to.eql(1);
+        expect(res.cursor).to.eql('cursor==');
         expect(res.per_page).to.eql(200);
-      });
-  });
-
-  it('should list customer subscriptions paged', () => {
-    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
-
-    const query = {
-      page: 1,
-      per_page: 25
-    };
-
-    nock(config.API_BASE)
-      .get(`/v1/customers/${customerUuid}/subscriptions`)
-      .query(query)
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [{
-          id: 297047,
-          plan: 'Bronze Plan',
-          quantity: 0,
-          mrr: 0,
-          arr: 0,
-          status: 'inactive',
-          'billing-cycle': 'month',
-          'billing-cycle-count': 1,
-          'start-date': '2016-01-15T00:00:00+00:00',
-          'end-date': '2016-01-15T00:00:00+00:00',
-          currency: 'USD',
-          'currency-sign': '$'
-        }],
-        has_more: false,
-        per_page: 25,
-        page: 1
-      /* eslint-enable camelcase */
-      });
-
-    return Metrics.Customer.subscriptions(config, customerUuid, query)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.per_page).to.eql(25);
-        expect(res.page).to.eql(1);
-      });
-  });
-
-  it('should list customer subscriptions with new pagination', () => {
-    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
-
-    nock(config.API_BASE)
-      .get(`/v1/customers/${customerUuid}/subscriptions`)
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [{
-          id: 297047,
-          plan: 'Bronze Plan',
-          quantity: 0,
-          mrr: 0,
-          arr: 0,
-          status: 'inactive',
-          'billing-cycle': 'month',
-          'billing-cycle-count': 1,
-          'start-date': '2016-01-15T00:00:00+00:00',
-          'end-date': '2016-01-15T00:00:00+00:00',
-          currency: 'USD',
-          'currency-sign': '$'
-        }],
-        has_more: false,
-        cursor: 'cursor=='
-      /* eslint-enable camelcase */
-      });
-
-    return Metrics.Customer.subscriptions(config, customerUuid)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.has_more).to.eql(false);
-        expect(res.cursor).to.eql('cursor==');
-      });
-  });
-
-  it('should list customer subscriptions cursored', () => {
-    const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
-
-    const query = { cursor: 'cursor==' };
-
-    nock(config.API_BASE)
-      .get(`/v1/customers/${customerUuid}/subscriptions`)
-      .query(query)
-      .reply(200, {
-      /* eslint-disable camelcase */
-        entries: [{
-          id: 297047,
-          plan: 'Bronze Plan',
-          quantity: 0,
-          mrr: 0,
-          arr: 0,
-          status: 'inactive',
-          'billing-cycle': 'month',
-          'billing-cycle-count': 1,
-          'start-date': '2016-01-15T00:00:00+00:00',
-          'end-date': '2016-01-15T00:00:00+00:00',
-          currency: 'USD',
-          'currency-sign': '$'
-        }],
-        has_more: false,
-        cursor: 'cursor=='
-      /* eslint-enable camelcase */
-      });
-
-    return Metrics.Customer.subscriptions(config, customerUuid, query)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.has_more).to.eql(false);
-        expect(res.cursor).to.eql('cursor==');
       });
   });
 });

--- a/test/chartmogul/plan-group.js
+++ b/test/chartmogul/plan-group.js
@@ -56,27 +56,26 @@ describe('PlanGroup', () => {
     });
   });
 
-  it('should get all plan groups with old pagination', () => {
+  it('throws DeprecatedParamError if using old pagination parameter', done => {
+    const query = {
+      page: 1
+    };
+
     nock(config.API_BASE)
       .get('/v1/plan_groups')
-      .reply(200, {
-      /* eslint-disable camelcase */
-        plan_groups: [],
-        current_page: 1,
-        total_pages: 0
-      /* eslint-enable camelcase */
-      });
-
-    return PlanGroup.all(config)
-      .then(res => {
-        expect(res).to.have.property('plan_groups');
-        expect(res.plan_groups).to.be.instanceof(Array);
-        expect(res.current_page).to.eql(1);
-        expect(res.total_pages).to.eql(0);
+      .query(query)
+      .reply(200, {});
+    PlanGroup.all(config, query)
+      .then(res => done(new Error('Should throw error')))
+      .catch(e => {
+        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
+        expect(e.httpStatus).to.equal(422);
+        expect(e.message).to.equal('"page" param is deprecated {}');
+        done();
       });
   });
 
-  it('should get all plan groups with new pagination', () => {
+  it('should get all plan groups with pagination', () => {
     nock(config.API_BASE)
       .get('/v1/plan_groups')
       .reply(200, {
@@ -96,49 +95,7 @@ describe('PlanGroup', () => {
       });
   });
 
-  it('should get all plans for a plan group with old pagination', () => {
-    const planGroupUUID = 'plg_eed05d54-75b4-431b-adb2-eb6b9e543206';
-
-    nock(config.API_BASE)
-      .get('/v1/plan_groups/' + planGroupUUID + '/plans')
-      .reply(200, {
-      /* eslint-disable camelcase */
-        plans: [
-          {
-            uuid: 'pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462',
-            external_id: 'plan_0001',
-            name: 'Bronze Plan',
-            interval_count: 1,
-            interval_unit: 'month',
-            data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-          },
-          {
-            uuid: 'pl_eed05d54-75b4-431b-adb2-eb6b9e543206',
-            external_id: 'plan_0001',
-            name: 'Bronze Plan',
-            interval_count: 1,
-            interval_unit: 'month',
-            data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-          }],
-        current_page: 1,
-        total_pages: 0
-      /* eslint-enable camelcase */
-      });
-
-    return PlanGroup.all(config, planGroupUUID, (err, res) => {
-      if (err) {
-        return err;
-      }
-      expect(res).to.have.property('plans');
-      expect(res.plans).to.be.instanceof(Array);
-      expect(res.plans[0].uuid).to.be.equal('pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462');
-      expect(res.plans[1].uuid).to.be.equal('pl_eed05d54-75b4-431b-adb2-eb6b9e543206');
-      expect(res.current_page).to.eql(1);
-      expect(res.total_pages).to.eql(0);
-    });
-  });
-
-  it('should get all plans for a plan group with new pagination', () => {
+  it('should get all plans for a plan group with pagination', () => {
     const planGroupUUID = 'plg_eed05d54-75b4-431b-adb2-eb6b9e543206';
 
     nock(config.API_BASE)

--- a/test/chartmogul/plan.js
+++ b/test/chartmogul/plan.js
@@ -37,27 +37,26 @@ describe('Plan', () => {
       });
   });
 
-  it('should get all plans with old pagination', () => {
+  it('throws DeprecatedParamError if using old pagination parameter', done => {
+    const query = {
+      page: 1
+    };
+
     nock(config.API_BASE)
       .get('/v1/plans')
-      .reply(200, {
-      /* eslint-disable camelcase */
-        plans: [],
-        current_page: 1,
-        total_pages: 0
-      /* eslint-enable camelcase */
-      });
-
-    return Plan.all(config)
-      .then(res => {
-        expect(res).to.have.property('plans');
-        expect(res.plans).to.be.instanceof(Array);
-        expect(res.current_page).to.eql(1);
-        expect(res.total_pages).to.eql(0);
+      .query(query)
+      .reply(200, {});
+    Plan.all(config, query)
+      .then(res => done(new Error('Should throw error')))
+      .catch(e => {
+        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
+        expect(e.httpStatus).to.equal(422);
+        expect(e.message).to.equal('"page" param is deprecated {}');
+        done();
       });
   });
 
-  it('should get all plans with new pagination', () => {
+  it('should get all plans with pagination', () => {
     nock(config.API_BASE)
       .get('/v1/plans')
       .reply(200, {

--- a/test/chartmogul/subscription.js
+++ b/test/chartmogul/subscription.js
@@ -64,36 +64,28 @@ describe('Subscription', () => {
       });
   });
 
-  it('should get all subscriptions with old pagination', () => {
+  it('throws DeprecatedParamError if using old pagination parameter', done => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
+    const query = {
+      page: 1,
+      customer_uuid: customerUUID
+    };
 
     nock(config.API_BASE)
       .get('/v1/import/customers/' + customerUUID + '/subscriptions')
-      .reply(200, {
-      /* eslint-disable camelcase */
-        customer_uuid: 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3',
-        subscriptions: [{
-          uuid: 'sub_0c26db04-9b58-423f-9a3b-fec4a3a61a88',
-          external_id: 'sub_0001',
-          cancellation_dates: [],
-          plan_uuid: 'pl_cff3a63c-3915-435e-a675-85a8a8ef4454',
-          data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-        }],
-        current_page: 1,
-        total_pages: 1
-      /* eslint-enable camelcase */
-      });
-
-    return Subscription.all(config, customerUUID)
-      .then(res => {
-        expect(res).to.have.property('subscriptions');
-        expect(res.subscriptions).to.be.instanceof(Array);
-        expect(res.current_page).to.eql(1);
-        expect(res.total_pages).to.eql(1);
+      .query(query)
+      .reply(200, {});
+    Subscription.all(config, query)
+      .then(res => done(new Error('Should throw error')))
+      .catch(e => {
+        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
+        expect(e.httpStatus).to.equal(422);
+        expect(e.message).to.equal('"page" param is deprecated {}');
+        done();
       });
   });
 
-  it('should get all subscriptions with new pagination', () => {
+  it('should list all subscriptions with pagination', () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)


### PR DESCRIPTION
After we released v2.1.2 to [add support for the cursor based pagination](https://github.com/chartmogul/chartmogul-node/tree/v2.1.2), this new version removes that support and will throw an error if the `page` pagination parameter is used.

It also removes support for Node 14 which is EOL for quite some time.