### PR TITLE
Fix missing `customer_uuid` when creating a note or retrieving all notes from a customer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [3.2.1] - 2023-12-20
+- Fix missing `customer_uuid` when creating a note or retrieving all notes from a customer
+
 ## [3.2.0] - 2023-12-20
 - Support customer notes
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ ChartMogul.Contact.all(config, { per_page: 10, cursor: 'cursor==' })
 ```js
 ChartMogul.CustomerNote.create(config, data)
 ChartMogul.CustomerNote.retrieve(config, noteUuid)
-ChartMogul.CustomerNote.patch(config, noteUuid)
+ChartMogul.CustomerNote.patch(config, noteUuid, {})
 ChartMogul.CustomerNote.destroy(config, noteUuid)
 ChartMogul.CustomerNote.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ ChartMogul.Contact.all(config, { per_page: 10, cursor: 'cursor==' })
 ```js
 ChartMogul.CustomerNote.create(config, data)
 ChartMogul.CustomerNote.retrieve(config, noteUuid)
-ChartMogul.CustomerNote.patch(config, noteUuid, {})
+ChartMogul.CustomerNote.patch(config, noteUuid, data)
 ChartMogul.CustomerNote.destroy(config, noteUuid)
 ChartMogul.CustomerNote.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
 

--- a/lib/chartmogul/customer.js
+++ b/lib/chartmogul/customer.js
@@ -31,12 +31,12 @@ class Customer extends Resource {
 
   static notes (config, customerId, params, callback) {
     const path = util.expandPath(CustomerNote.path, []);
-    return Resource.request(config, 'GET', path, { ...params, customerId }, callback);
+    return Resource.request(config, 'GET', path, { ...params, customer_uuid: customerId }, callback);
   }
 
-  static createrNote (config, customerId, params, callback) {
+  static createNote (config, customerId, params, callback) {
     const path = util.expandPath(CustomerNote.path, []);
-    return Resource.request(config, 'POST', path, { ...params, customerId }, callback);
+    return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerId }, callback);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -191,7 +191,6 @@ describe('Customer', () => {
   it('creates a new note from a customer', () => {
     const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
     const postBody = {
-      customer_uuid: customerUuid,
       type: 'note',
       author_email: 'john@example.com',
       note: 'This is a note'
@@ -209,7 +208,7 @@ describe('Customer', () => {
         type: 'note'
       });
 
-    Customer.createrNote(config, customerUuid, postBody)
+    Customer.createNote(config, customerUuid, postBody)
       .then(res => {
         expect(res).to.have.property('uuid');
       });


### PR DESCRIPTION
Fix missing customer_uuid when creating a note or retrieving all notes from a customer