### PR TITLE
Fix query string not passed after replacing `request` library with `superagent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-## [3.2.3] - 2023-01-19
+## [3.2.4] - 2024-02-17
+- Fix query string not passed after replacing `request` library with `superagent`
+
+## [3.2.3] - 2024-01-19
 - Actually remove the `requests` library from `package.json`
 
-## [3.2.2] - 2023-01-18
+## [3.2.2] - 2024-01-18
 - Remove the `requests` library and use `superagent` instead
 
 ## [3.2.1] - 2023-12-20

--- a/lib/chartmogul/util/retry.js
+++ b/lib/chartmogul/util/retry.js
@@ -49,6 +49,7 @@ module.exports = function retryRequest (retries, options, cb) {
     const request = superagent(options.method || 'get', requestUrl)
       .auth(options.auth.user, options.auth.pass)
       .set(options.headers)
+      .query(options.qs)
       .send(options.body);
 
     request.end((err, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "3.2.2",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "3.2.2",
+      "version": "3.2.4",
       "license": "MIT",
       "dependencies": {
         "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {


### PR DESCRIPTION
Crucial fix for https://github.com/chartmogul/chartmogul-node/issues/91