### PR TITLE
Pass query string to superagent in retryRequest

### DIFF
--- a/lib/chartmogul/util/retry.js
+++ b/lib/chartmogul/util/retry.js
@@ -49,6 +49,7 @@ module.exports = function retryRequest (retries, options, cb) {
     const request = superagent(options.method || 'get', requestUrl)
       .auth(options.auth.user, options.auth.pass)
       .set(options.headers)
+      .query(options.qs)
       .send(options.body);
 
     request.end((err, res) => {


### PR DESCRIPTION
Ran into an issue where this wasn't working:

```
ChartMogul.Customer.search(config, {
   email: 'bob@acme.com' });
```

I was getting 400 errors with:

> '{"code":400,"message":"Parameter \\"email\\" is missing","param":"email"}'

Looks like the querystring isn't being passed into the request. This fixes it.    