### PR TITLE
Marcinrog fix passing query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-## [3.2.4] - 2024-02-17
+## [3.3.2] - 2024-02-28
 - Fix query string not passed after replacing `request` library with `superagent`
 
 ## [3.2.3] - 2024-01-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
-## [3.2.3] - 2023-01-19
+## [3.2.4] - 2024-02-17
+- Fix query string not passed after replacing `request` library with `superagent`
+
+## [3.2.3] - 2024-01-19
 - Actually remove the `requests` library from `package.json`
 
-## [3.2.2] - 2023-01-18
+## [3.2.2] - 2024-01-18
 - Remove the `requests` library and use `superagent` instead
 
 ## [3.2.1] - 2023-12-20

--- a/lib/chartmogul/util/retry.js
+++ b/lib/chartmogul/util/retry.js
@@ -49,6 +49,7 @@ module.exports = function retryRequest (retries, options, cb) {
     const request = superagent(options.method || 'get', requestUrl)
       .auth(options.auth.user, options.auth.pass)
       .set(options.headers)
+      .query(options.qs)
       .send(options.body);
 
     request.end((err, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "3.2.2",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "3.2.2",
+      "version": "3.2.4",
       "license": "MIT",
       "dependencies": {
         "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.2.4",
+  "version": "3.3.2",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/util/retry.js
+++ b/test/chartmogul/util/retry.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const ChartMogul = require('../../../lib/chartmogul');
+const expect = require('chai').expect;
+const nock = require('nock');
+const config = new ChartMogul.Config('token');
+const retryRequest = require('../../../lib/chartmogul/util/retry');
+
+describe('RetryTest', () => {
+  config.retries = 2;
+  const mockSuccessResponse = { success: true };
+
+  it('should retry on network error and then succeed', done => {
+    const query = { email: 'bob@acme.com' };
+
+    nock(config.API_BASE)
+      .get('/v1/metrics/all')
+      .query(query)
+      .replyWithError({ code: 'ECONNRESET' })
+      .get('/v1/metrics/all')
+      .query(query)
+      .reply(200, mockSuccessResponse);
+
+    const options = {
+      uri: '/v1/metrics/all',
+      baseUrl: config.API_BASE,
+      method: 'GET',
+      auth: {
+        user: config.getApiKey(),
+        pass: ''
+      },
+      qs: { email: 'bob@acme.com' },
+      headers: {
+        'User-Agent': 'chartmogul-node/' + config.VERSION
+      }
+    };
+
+    retryRequest(config.retries, options, (err, res, body) => {
+      expect(err).to.equal(null);
+      expect(body).to.deep.equal(mockSuccessResponse);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the issue [#91](https://github.com/chartmogul/chartmogul-node/issues/91). 
And a test is added for retry function. 

As per the changelog, in version 3.3.2, the issue with the query string not being passed after replacing the `request` library with `superagent` has been fixed. 

Please ensure to update your package to the latest version to benefit from this fix. 

If you're still encountering the issue after updating, please provide more details about your use case and we'll be happy to look into it further.