### PR TITLE
feat(sc-57429): Support Opportunities API

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ ChartMogul.Customer.createContact(config, customerUuid, data)
 
 ChartMogul.Customer.notes(config, customerUuid, { per_page: 10, cursor: 'cursor==' })
 ChartMogul.Customer.createNote(config, customerUuid, data)
+
+ChartMogul.Customer.opportunities(config, customerUuid, { per_page: 10, cursor: 'cursor==' })
+ChartMogul.Customer.createOpportunity(config, customerUuid, data)
 ```
 
 #### [Contacts](https://dev.chartmogul.com/docs/contacts)
@@ -149,6 +152,16 @@ ChartMogul.CustomerNote.patch(config, noteUuid, data)
 ChartMogul.CustomerNote.destroy(config, noteUuid)
 ChartMogul.CustomerNote.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
 
+```
+
+#### [Opportunities](https://dev.chartmogul.com/docs/opportunities)
+
+```js
+ChartMogul.Opportunity.create(config, data)
+ChartMogul.Opportunity.retrieve(config, opportunityUuid)
+ChartMogul.Opportunity.patch(config, opportunityUuid, data)
+ChartMogul.Opportunity.destroy(config, opportunityUuid)
+ChartMogul.Opportunity.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
 ```
 
 

--- a/lib/chartmogul.js
+++ b/lib/chartmogul.js
@@ -7,6 +7,7 @@ const Customer = require('./chartmogul/customer');
 const CustomerNote = require('./chartmogul/customer-note');
 const Contact = require('./chartmogul/contact');
 const DataSource = require('./chartmogul/data-source');
+const Opportunity = require('./chartmogul/opportunity');
 const Plan = require('./chartmogul/plan');
 const PlanGroup = require('./chartmogul/plan-group');
 const Ping = require('./chartmogul/ping');
@@ -38,6 +39,7 @@ const ChartMogul = {
   Import,
   Invoice,
   Metrics,
+  Opportunity,
   Ping,
   Plan,
   PlanGroup,

--- a/lib/chartmogul/customer.js
+++ b/lib/chartmogul/customer.js
@@ -3,6 +3,7 @@
 const Resource = require('./resource');
 const util = require('./util');
 const CustomerNote = require('./customer-note');
+const Opportunity = require('./opportunity');
 
 class Customer extends Resource {
   static get path () {
@@ -36,6 +37,16 @@ class Customer extends Resource {
 
   static createNote (config, customerId, params, callback) {
     const path = util.expandPath(CustomerNote.path, []);
+    return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerId }, callback);
+  }
+
+  static opportunities (config, customerId, params, callback) {
+    const path = util.expandPath(Opportunity.path, []);
+    return Resource.request(config, 'GET', path, { ...params, customer_uuid: customerId }, callback);
+  }
+
+  static createOpportunity (config, customerId, params, callback) {
+    const path = util.expandPath(Opportunity.path, []);
     return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerId }, callback);
   }
 }

--- a/lib/chartmogul/opportunity.js
+++ b/lib/chartmogul/opportunity.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Resource = require('./resource');
+
+class Opportunity extends Resource {
+  static get path () {
+    return '/v1/opportunities{/opportunityUuid}';
+  }
+}
+
+module.exports = Opportunity;

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -256,7 +256,7 @@ describe('Customer', () => {
       type: 'recurring',
       forecast_category: 'pipeline',
       win_likelihood: 3,
-      custom: [{ key: 'from_campain', value: 'true' }]
+      custom: [{ key: 'from_campaign', value: 'true' }]
     };
 
     nock(config.API_BASE)
@@ -273,7 +273,7 @@ describe('Customer', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campain: 'true' },
+        custom: { from_campaign: 'true' },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
@@ -290,7 +290,7 @@ describe('Customer', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
   });
 
   it('gets all opportunities from a customer', async () => {
@@ -311,7 +311,7 @@ describe('Customer', () => {
           type: 'recurring',
           forecast_category: 'pipeline',
           win_likelihood: 3,
-          custom: { from_campain: 'true' },
+          custom: { from_campaign: 'true' },
           created_at: '2024-03-13T07:33:28.356Z',
           updated_at: '2024-03-13T07:33:28.356Z'
         }],

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -242,6 +242,89 @@ describe('Customer', () => {
         expect(res.has_more).to.eql(false);
       });
   });
+
+  it('creates a new opportunity from a customer', async () => {
+    const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
+    const postBody = {
+      customer_uuid: customerUuid,
+      owner: 'test1@example.org',
+      pipeline: 'New business 1',
+      pipeline_stage: 'Discovery',
+      estimated_close_date: '2023-12-22',
+      currency: 'USD',
+      amount_in_cents: 100,
+      type: 'recurring',
+      forecast_category: 'pipeline',
+      win_likelihood: 3,
+      custom: [{ key: 'from_campain', value: 'true' }]
+    };
+
+    nock(config.API_BASE)
+      .post('/v1/opportunities', postBody)
+      .reply(200, {
+        uuid: '00000000-0000-0000-0000-000000000000',
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        owner: 'test1@example.org',
+        pipeline: 'New business 1',
+        pipeline_stage: 'Discovery',
+        estimated_close_date: '2023-12-22',
+        currency: 'USD',
+        amount_in_cents: 100,
+        type: 'recurring',
+        forecast_category: 'pipeline',
+        win_likelihood: 3,
+        custom: { from_campain: 'true' },
+        created_at: '2024-03-13T07:33:28.356Z',
+        updated_at: '2024-03-13T07:33:28.356Z'
+      });
+
+    const opportunity = await Customer.createOpportunity(config, customerUuid, postBody);
+    expect(opportunity.uuid).to.be.equal('00000000-0000-0000-0000-000000000000');
+    expect(opportunity.customer_uuid).to.be.equal(customerUuid);
+    expect(opportunity.owner).to.be.equal('test1@example.org');
+    expect(opportunity.pipeline).to.be.equal('New business 1');
+    expect(opportunity.pipeline_stage).to.be.equal('Discovery');
+    expect(opportunity.estimated_close_date).to.be.equal('2023-12-22');
+    expect(opportunity.currency).to.be.equal('USD');
+    expect(opportunity.amount_in_cents).to.be.equal(100);
+    expect(opportunity.type).to.be.equal('recurring');
+    expect(opportunity.forecast_category).to.be.equal('pipeline');
+    expect(opportunity.win_likelihood).to.be.equal(3);
+    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+  });
+
+  it('gets all opportunities from a customer', async () => {
+    const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
+
+    nock(config.API_BASE)
+      .get(`/v1/opportunities?customer_uuid=${customerUuid}`)
+      .reply(200, {
+        entries: [{
+          uuid: '00000000-0000-0000-0000-000000000000',
+          customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+          owner: 'test1@example.org',
+          pipeline: 'New business 1',
+          pipeline_stage: 'Discovery',
+          estimated_close_date: '2023-12-22',
+          currency: 'USD',
+          amount_in_cents: 100,
+          type: 'recurring',
+          forecast_category: 'pipeline',
+          win_likelihood: 3,
+          custom: { from_campain: 'true' },
+          created_at: '2024-03-13T07:33:28.356Z',
+          updated_at: '2024-03-13T07:33:28.356Z'
+        }],
+        cursor: 'MjAyMy0wMy0xM1QxMjowMTozMi44MD==',
+        has_more: false
+      });
+
+    const opportunities = await Customer.opportunities(config, customerUuid);
+    expect(opportunities).to.have.property('entries');
+    expect(opportunities.entries).to.be.instanceof(Array);
+    expect(opportunities.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+    expect(opportunities.has_more).to.eql(false);
+  });
 });
 
 /** Suite that originally belonged in the Enrichment module.

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -256,7 +256,7 @@ describe('Customer', () => {
       type: 'recurring',
       forecast_category: 'pipeline',
       win_likelihood: 3,
-      custom: [{ key: 'from_campaign', value: 'true' }]
+      custom: [{ key: 'from_campaign', value: true }]
     };
 
     nock(config.API_BASE)
@@ -273,7 +273,7 @@ describe('Customer', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campaign: 'true' },
+        custom: { from_campaign: true },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
@@ -290,7 +290,7 @@ describe('Customer', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: true });
   });
 
   it('gets all opportunities from a customer', async () => {
@@ -311,7 +311,7 @@ describe('Customer', () => {
           type: 'recurring',
           forecast_category: 'pipeline',
           win_likelihood: 3,
-          custom: { from_campaign: 'true' },
+          custom: { from_campaign: true },
           created_at: '2024-03-13T07:33:28.356Z',
           updated_at: '2024-03-13T07:33:28.356Z'
         }],

--- a/test/chartmogul/opportunity.js
+++ b/test/chartmogul/opportunity.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const ChartMogul = require('../../lib/chartmogul');
+const config = new ChartMogul.Config('token');
+const expect = require('chai').expect;
+const nock = require('nock');
+const Opportunity = ChartMogul.Opportunity;
+
+describe('Opportunity', () => {
+  it('creates a opportunity for a customer', async () => {
+    const uuid = 'cus_00000000-0000-0000-0000-000000000000';
+    const postBody = {
+      customer_uuid: uuid,
+      owner: 'test1@example.org',
+      pipeline: 'New business 1',
+      pipeline_stage: 'Discovery',
+      estimated_close_date: '2023-12-22',
+      currency: 'USD',
+      amount_in_cents: 100,
+      type: 'recurring',
+      forecast_category: 'pipeline',
+      win_likelihood: 3,
+      custom: [{ key: 'from_campain', value: 'true' }]
+    };
+
+    nock(config.API_BASE)
+      .post('/v1/opportunities', postBody)
+      .reply(200, {
+        uuid: '00000000-0000-0000-0000-000000000000',
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        owner: 'test1@example.org',
+        pipeline: 'New business 1',
+        pipeline_stage: 'Discovery',
+        estimated_close_date: '2023-12-22',
+        currency: 'USD',
+        amount_in_cents: 100,
+        type: 'recurring',
+        forecast_category: 'pipeline',
+        win_likelihood: 3,
+        custom: { from_campain: 'true' },
+        created_at: '2024-03-13T07:33:28.356Z',
+        updated_at: '2024-03-13T07:33:28.356Z'
+      });
+
+    const opportunity = await Opportunity.create(config, postBody);
+    expect(opportunity.customer_uuid).to.be.equal(uuid);
+    expect(opportunity.owner).to.be.equal('test1@example.org');
+    expect(opportunity.pipeline).to.be.equal('New business 1');
+    expect(opportunity.pipeline_stage).to.be.equal('Discovery');
+    expect(opportunity.estimated_close_date).to.be.equal('2023-12-22');
+    expect(opportunity.currency).to.be.equal('USD');
+    expect(opportunity.amount_in_cents).to.be.equal(100);
+    expect(opportunity.type).to.be.equal('recurring');
+    expect(opportunity.forecast_category).to.be.equal('pipeline');
+    expect(opportunity.win_likelihood).to.be.equal(3);
+    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+  });
+
+  it('lists all opportunities from a customer', async () => {
+    const uuid = 'cus_00000000-0000-0000-0000-000000000000';
+
+    nock(config.API_BASE)
+      .get(`/v1/opportunities/${uuid}`)
+      .reply(200, {
+        entries: [
+          {
+            uuid: '00000000-0000-0000-0000-000000000000',
+            customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+            owner: 'test1@example.org',
+            pipeline: 'New business 1',
+            pipeline_stage: 'Discovery',
+            estimated_close_date: '2023-12-22',
+            currency: 'USD',
+            amount_in_cents: 100,
+            type: 'recurring',
+            forecast_category: 'pipeline',
+            win_likelihood: 3,
+            custom: { from_campain: 'true' },
+            created_at: '2024-03-13T07:33:28.356Z',
+            updated_at: '2024-03-13T07:33:28.356Z'
+          }
+        ]
+      });
+
+    const opportunity = await Opportunity.all(config, uuid);
+    expect(opportunity.entries).to.have.length(1);
+  });
+
+  it('retrieves an opportunity', async () => {
+    const uuid = '00000000-0000-0000-0000-000000000000';
+
+    nock(config.API_BASE)
+      .get(`/v1/opportunities/${uuid}`)
+      .reply(200, {
+        uuid: '00000000-0000-0000-0000-000000000000',
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        owner: 'test1@example.org',
+        pipeline: 'New business 1',
+        pipeline_stage: 'Discovery',
+        estimated_close_date: '2023-12-22',
+        currency: 'USD',
+        amount_in_cents: 100,
+        type: 'recurring',
+        forecast_category: 'pipeline',
+        win_likelihood: 3,
+        custom: { from_campain: 'true' },
+        created_at: '2024-03-13T07:33:28.356Z',
+        updated_at: '2024-03-13T07:33:28.356Z'
+      });
+
+    const opportunity = await Opportunity.retrieve(config, uuid);
+    expect(opportunity.uuid).to.be.equal(uuid);
+    expect(opportunity.customer_uuid).to.be.equal('cus_00000000-0000-0000-0000-000000000000');
+    expect(opportunity.owner).to.be.equal('test1@example.org');
+    expect(opportunity.pipeline).to.be.equal('New business 1');
+    expect(opportunity.pipeline_stage).to.be.equal('Discovery');
+    expect(opportunity.estimated_close_date).to.be.equal('2023-12-22');
+    expect(opportunity.currency).to.be.equal('USD');
+    expect(opportunity.amount_in_cents).to.be.equal(100);
+    expect(opportunity.type).to.be.equal('recurring');
+    expect(opportunity.forecast_category).to.be.equal('pipeline');
+    expect(opportunity.win_likelihood).to.be.equal(3);
+    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+  });
+
+  it('updates an opportunity', async () => {
+    const uuid = '00000000-0000-0000-0000-000000000000';
+    const postBody = {
+      estimated_close_date: '2024-12-22'
+    };
+
+    nock(config.API_BASE)
+      .patch(`/v1/opportunities/${uuid}`, postBody)
+      .reply(200, {
+        uuid: '00000000-0000-0000-0000-000000000000',
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        owner: 'test1@example.org',
+        pipeline: 'New business 1',
+        pipeline_stage: 'Discovery',
+        estimated_close_date: '2024-12-22',
+        currency: 'USD',
+        amount_in_cents: 100,
+        type: 'recurring',
+        forecast_category: 'pipeline',
+        win_likelihood: 3,
+        custom: { from_campain: 'true' },
+        created_at: '2024-03-13T07:33:28.356Z',
+        updated_at: '2024-03-13T07:33:28.356Z'
+      });
+
+    const opportunity = await Opportunity.patch(config, uuid, postBody);
+    expect(opportunity.uuid).to.be.equal(uuid);
+    expect(opportunity.customer_uuid).to.be.equal('cus_00000000-0000-0000-0000-000000000000');
+    expect(opportunity.owner).to.be.equal('test1@example.org');
+    expect(opportunity.pipeline).to.be.equal('New business 1');
+    expect(opportunity.pipeline_stage).to.be.equal('Discovery');
+    expect(opportunity.estimated_close_date).to.be.equal('2024-12-22');
+    expect(opportunity.currency).to.be.equal('USD');
+    expect(opportunity.amount_in_cents).to.be.equal(100);
+    expect(opportunity.type).to.be.equal('recurring');
+    expect(opportunity.forecast_category).to.be.equal('pipeline');
+    expect(opportunity.win_likelihood).to.be.equal(3);
+    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+  });
+
+  it('deletes an opportunity', async () => {
+    const uuid = '00000000-0000-0000-0000-000000000000';
+
+    nock(config.API_BASE).delete(`/v1/opportunities/${uuid}`).reply(204);
+
+    const result = await Opportunity.destroy(config, uuid);
+    expect(result).to.deep.equal({});
+  });
+});

--- a/test/chartmogul/opportunity.js
+++ b/test/chartmogul/opportunity.js
@@ -20,7 +20,7 @@ describe('Opportunity', () => {
       type: 'recurring',
       forecast_category: 'pipeline',
       win_likelihood: 3,
-      custom: [{ key: 'from_campaign', value: 'true' }]
+      custom: [{ key: 'from_campaign', value: true }]
     };
 
     nock(config.API_BASE)
@@ -37,7 +37,7 @@ describe('Opportunity', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campaign: 'true' },
+        custom: { from_campaign: true },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
@@ -53,7 +53,7 @@ describe('Opportunity', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: true });
   });
 
   it('lists all opportunities from a customer', async () => {
@@ -75,7 +75,7 @@ describe('Opportunity', () => {
             type: 'recurring',
             forecast_category: 'pipeline',
             win_likelihood: 3,
-            custom: { from_campaign: 'true' },
+            custom: { from_campaign: true },
             created_at: '2024-03-13T07:33:28.356Z',
             updated_at: '2024-03-13T07:33:28.356Z'
           }
@@ -103,7 +103,7 @@ describe('Opportunity', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campaign: 'true' },
+        custom: { from_campaign: true },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
@@ -122,7 +122,7 @@ describe('Opportunity', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: true });
   });
 
   it('updates an opportunity', async () => {
@@ -145,7 +145,7 @@ describe('Opportunity', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campaign: 'true' },
+        custom: { from_campaign: true },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
@@ -164,7 +164,7 @@ describe('Opportunity', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: true });
   });
 
   it('deletes an opportunity', async () => {

--- a/test/chartmogul/opportunity.js
+++ b/test/chartmogul/opportunity.js
@@ -20,7 +20,7 @@ describe('Opportunity', () => {
       type: 'recurring',
       forecast_category: 'pipeline',
       win_likelihood: 3,
-      custom: [{ key: 'from_campain', value: 'true' }]
+      custom: [{ key: 'from_campaign', value: 'true' }]
     };
 
     nock(config.API_BASE)
@@ -37,7 +37,7 @@ describe('Opportunity', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campain: 'true' },
+        custom: { from_campaign: 'true' },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
@@ -53,7 +53,7 @@ describe('Opportunity', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
   });
 
   it('lists all opportunities from a customer', async () => {
@@ -75,7 +75,7 @@ describe('Opportunity', () => {
             type: 'recurring',
             forecast_category: 'pipeline',
             win_likelihood: 3,
-            custom: { from_campain: 'true' },
+            custom: { from_campaign: 'true' },
             created_at: '2024-03-13T07:33:28.356Z',
             updated_at: '2024-03-13T07:33:28.356Z'
           }
@@ -103,14 +103,16 @@ describe('Opportunity', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campain: 'true' },
+        custom: { from_campaign: 'true' },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
 
     const opportunity = await Opportunity.retrieve(config, uuid);
     expect(opportunity.uuid).to.be.equal(uuid);
-    expect(opportunity.customer_uuid).to.be.equal('cus_00000000-0000-0000-0000-000000000000');
+    expect(opportunity.customer_uuid).to.be.equal(
+      'cus_00000000-0000-0000-0000-000000000000'
+    );
     expect(opportunity.owner).to.be.equal('test1@example.org');
     expect(opportunity.pipeline).to.be.equal('New business 1');
     expect(opportunity.pipeline_stage).to.be.equal('Discovery');
@@ -120,7 +122,7 @@ describe('Opportunity', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
   });
 
   it('updates an opportunity', async () => {
@@ -143,14 +145,16 @@ describe('Opportunity', () => {
         type: 'recurring',
         forecast_category: 'pipeline',
         win_likelihood: 3,
-        custom: { from_campain: 'true' },
+        custom: { from_campaign: 'true' },
         created_at: '2024-03-13T07:33:28.356Z',
         updated_at: '2024-03-13T07:33:28.356Z'
       });
 
     const opportunity = await Opportunity.patch(config, uuid, postBody);
     expect(opportunity.uuid).to.be.equal(uuid);
-    expect(opportunity.customer_uuid).to.be.equal('cus_00000000-0000-0000-0000-000000000000');
+    expect(opportunity.customer_uuid).to.be.equal(
+      'cus_00000000-0000-0000-0000-000000000000'
+    );
     expect(opportunity.owner).to.be.equal('test1@example.org');
     expect(opportunity.pipeline).to.be.equal('New business 1');
     expect(opportunity.pipeline_stage).to.be.equal('Discovery');
@@ -160,7 +164,7 @@ describe('Opportunity', () => {
     expect(opportunity.type).to.be.equal('recurring');
     expect(opportunity.forecast_category).to.be.equal('pipeline');
     expect(opportunity.win_likelihood).to.be.equal(3);
-    expect(opportunity.custom).to.deep.equal({ from_campain: 'true' });
+    expect(opportunity.custom).to.deep.equal({ from_campaign: 'true' });
   });
 
   it('deletes an opportunity', async () => {


### PR DESCRIPTION
closes ticket: https://app.shortcut.com/chartmogul/story/57429/support-opportunities-resource-node-client

API Specs: https://www.notion.so/chartmogul/API-endpoints-for-Opportunities-a92323514bf44f89ad2f97ae30cee7f0#6f09cc7a71bc40e69ef65d8d0342d230

### Background
There were added following methods to the library

**Customers**
```js
ChartMogul.Customer.opportunities(config, customerUuid, { per_page: 10, cursor: 'cursor==' })
ChartMogul.Customer.createOpportunity(config, customerUuid, data)
```

Opportunities
```js
ChartMogul.Opportunity.create(config, data)
ChartMogul.Opportunity.retrieve(config, opportunityUuid)
ChartMogul.Opportunity.patch(config, opportunityUuid, data)
ChartMogul.Opportunity.destroy(config, opportunityUuid)
ChartMogul.Opportunity.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
```

### Tests
Regarding the tests, you will be probably suprised about the other approach of tests, but I found out that all existing tests are **incorrect** for all the resources. Iwrote the tests for the opportunity in good way, but fixing all the others will take some time, so needs to be addressed independently. Will ping about it to the engineering channnel.

The issue is that we assert value in promise block with no return. This way the test will pass even though the assertion is false.
```
 Customer.createContact(config, customerUuid, postBody)
      .then(res => {
        expect(res).to.have.property('uuid');
      });
```
