### PR TITLE
Fix bug in assertions returning true for some tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning].
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+## [3.5.0] - 2024-04-08
+- BUG: Improve all tests that always return true (https://github.com/chartmogul/chartmogul-node/pull/100)
 
 ## [3.4.0] - 2024-03-25
 - Adds support for Opportunities (https://dev.chartmogul.com/reference/opportunities)

--- a/package.json
+++ b/package.json
@@ -1,53 +1,53 @@
 {
-  "name": "chartmogul-node",
-  "version": "3.4.0",
-  "description": "Official Chartmogul API Node.js Client",
-  "main": "lib/chartmogul.js",
-  "scripts": {
-    "test": "mocha",
-    "lint": "eslint --fix .",
-    "cover": "nyc mocha",
-    "prepare": "npm run lint && npm run test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/chartmogul/chartmogul-node.git"
-  },
-  "keywords": [
-    "chartmogul",
-    "api"
-  ],
-  "author": "ChartMogul Ltd. <support@chartmogul.com>",
-  "contributors": [
-    "Mahmudul Hassan <hassan@chartmogul.com>"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/chartmogul/chartmogul-node/issues"
-  },
-  "homepage": "https://github.com/chartmogul/chartmogul-node",
-  "engines": {
-    "node": ">=16"
-  },
-  "dependencies": {
-    "retry": "^0.13.1",
-    "superagent": "^8.1.2",
-    "uri-templates": "^0.2.0"
-  },
-  "devDependencies": {
-    "@babel/traverse": ">=7.23.2",
-    "chai": "",
-    "dependency-lint": "^7.1.0",
-    "eslint": "^8.54.0",
-    "eslint-config-standard": "",
-    "eslint-plugin-import": "",
-    "eslint-plugin-n": "",
-    "eslint-plugin-promise": "",
-    "eslint-plugin-standard": "",
-    "mocha": "",
-    "nock": "",
-    "nyc": "^15.1.0",
-    "pre-commit": ""
-  },
-  "pre-commit": "prepare"
+	"name": "chartmogul-node",
+	"version": "3.5.0",
+	"description": "Official Chartmogul API Node.js Client",
+	"main": "lib/chartmogul.js",
+	"scripts": {
+		"test": "mocha",
+		"lint": "eslint --fix .",
+		"cover": "nyc mocha",
+		"prepare": "npm run lint && npm run test"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/chartmogul/chartmogul-node.git"
+	},
+	"keywords": [
+		"chartmogul",
+		"api"
+	],
+	"author": "ChartMogul Ltd. <support@chartmogul.com>",
+	"contributors": [
+		"Mahmudul Hassan <hassan@chartmogul.com>"
+	],
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/chartmogul/chartmogul-node/issues"
+	},
+	"homepage": "https://github.com/chartmogul/chartmogul-node",
+	"engines": {
+		"node": ">=16"
+	},
+	"dependencies": {
+		"retry": "^0.13.1",
+		"superagent": "^8.1.2",
+		"uri-templates": "^0.2.0"
+	},
+	"devDependencies": {
+		"@babel/traverse": ">=7.23.2",
+		"chai": "",
+		"dependency-lint": "^7.1.0",
+		"eslint": "^8.54.0",
+		"eslint-config-standard": "",
+		"eslint-plugin-import": "",
+		"eslint-plugin-n": "",
+		"eslint-plugin-promise": "",
+		"eslint-plugin-standard": "",
+		"mocha": "",
+		"nock": "",
+		"nyc": "^15.1.0",
+		"pre-commit": ""
+	},
+	"pre-commit": "prepare"
 }

--- a/package.json
+++ b/package.json
@@ -1,53 +1,53 @@
 {
-	"name": "chartmogul-node",
-	"version": "3.5.0",
-	"description": "Official Chartmogul API Node.js Client",
-	"main": "lib/chartmogul.js",
-	"scripts": {
-		"test": "mocha",
-		"lint": "eslint --fix .",
-		"cover": "nyc mocha",
-		"prepare": "npm run lint && npm run test"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/chartmogul/chartmogul-node.git"
-	},
-	"keywords": [
-		"chartmogul",
-		"api"
-	],
-	"author": "ChartMogul Ltd. <support@chartmogul.com>",
-	"contributors": [
-		"Mahmudul Hassan <hassan@chartmogul.com>"
-	],
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/chartmogul/chartmogul-node/issues"
-	},
-	"homepage": "https://github.com/chartmogul/chartmogul-node",
-	"engines": {
-		"node": ">=16"
-	},
-	"dependencies": {
-		"retry": "^0.13.1",
-		"superagent": "^8.1.2",
-		"uri-templates": "^0.2.0"
-	},
-	"devDependencies": {
-		"@babel/traverse": ">=7.23.2",
-		"chai": "",
-		"dependency-lint": "^7.1.0",
-		"eslint": "^8.54.0",
-		"eslint-config-standard": "",
-		"eslint-plugin-import": "",
-		"eslint-plugin-n": "",
-		"eslint-plugin-promise": "",
-		"eslint-plugin-standard": "",
-		"mocha": "",
-		"nock": "",
-		"nyc": "^15.1.0",
-		"pre-commit": ""
-	},
-	"pre-commit": "prepare"
+  "name": "chartmogul-node",
+  "version": "3.4.0",
+  "description": "Official Chartmogul API Node.js Client",
+  "main": "lib/chartmogul.js",
+  "scripts": {
+    "test": "mocha",
+    "lint": "eslint --fix .",
+    "cover": "nyc mocha",
+    "prepare": "npm run lint && npm run test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chartmogul/chartmogul-node.git"
+  },
+  "keywords": [
+    "chartmogul",
+    "api"
+  ],
+  "author": "ChartMogul Ltd. <support@chartmogul.com>",
+  "contributors": [
+    "Mahmudul Hassan <hassan@chartmogul.com>"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/chartmogul/chartmogul-node/issues"
+  },
+  "homepage": "https://github.com/chartmogul/chartmogul-node",
+  "engines": {
+    "node": ">=16"
+  },
+  "dependencies": {
+    "retry": "^0.13.1",
+    "superagent": "^8.1.2",
+    "uri-templates": "^0.2.0"
+  },
+  "devDependencies": {
+    "@babel/traverse": ">=7.23.2",
+    "chai": "",
+    "dependency-lint": "^7.1.0",
+    "eslint": "^8.54.0",
+    "eslint-config-standard": "",
+    "eslint-plugin-import": "",
+    "eslint-plugin-n": "",
+    "eslint-plugin-promise": "",
+    "eslint-plugin-standard": "",
+    "mocha": "",
+    "nock": "",
+    "nyc": "^15.1.0",
+    "pre-commit": ""
+  },
+  "pre-commit": "prepare"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/account.js
+++ b/test/chartmogul/account.js
@@ -7,26 +7,22 @@ const nock = require('nock');
 const Account = ChartMogul.Account;
 
 describe('Account', () => {
-  it('should retrieve the details of current account', () => {
+  it('should retrieve the details of current account', async () => {
     nock(config.API_BASE)
       .get('/v1/account')
       .reply(200, {
-      /* eslint-disable camelcase */
+        /* eslint-disable camelcase */
         name: 'Example Test Company',
         currency: 'EUR',
         time_zone: 'Europe/Berlin',
         week_start_on: 'sunday'
-      /* eslint-enable camelcase */
+        /* eslint-enable camelcase */
       });
 
-    return Account.retrieve(config, (err, res) => {
-      if (err) {
-        return err;
-      }
-      expect(res.name).to.be.equal('Example Test Company');
-      expect(res.currency).to.be.equal('EUR');
-      expect(res.time_zone).to.be.equal('Europe/Berlin');
-      expect(res.week_start_on).to.be.equal('sunday');
-    });
+    const account = await Account.retrieve(config);
+    expect(account.name).to.be.equal('Example Test Company');
+    expect(account.currency).to.be.equal('EUR');
+    expect(account.time_zone).to.be.equal('Europe/Berlin');
+    expect(account.week_start_on).to.be.equal('sunday');
   });
 });

--- a/test/chartmogul/custom-attribute.js
+++ b/test/chartmogul/custom-attribute.js
@@ -27,6 +27,8 @@ describe('CustomAttribute', () => {
     return CustomAttribute.add(config, customerUuid, postBody)
       .then(res => {
         expect(res).to.have.property('custom');
+        expect(res.custom.channel).to.be.equal('Facebook');
+        expect(res.custom.age).to.be.equal(8);
       });
   });
 

--- a/test/chartmogul/customer-note.js
+++ b/test/chartmogul/customer-note.js
@@ -27,18 +27,19 @@ describe('CustomerNote', () => {
         author: 'John Doe (john@example.com)'
       });
 
-    CustomerNote.create(config, postBody)
+    return CustomerNote.create(config, postBody)
       .then(res => {
         expect(res.customer_uuid).to.be.equal(uuid);
         expect(res.text).to.be.equal('This is a note');
       });
   });
 
-  it('lists all notes from a customer', () => {
+  it('lists all notes from a customer', async () => {
     const uuid = 'cus_00000000-0000-0000-0000-000000000000';
+    const body = { customer_uuid: uuid, per_page: 10, cursor: 'cursor==' };
 
     nock(config.API_BASE)
-      .get('/v1/customer_notes')
+      .get(`/v1/customer_notes?customer_uuid=${uuid}&per_page=10&cursor=cursor==`)
       .reply(200, {
         entries: [{
           uuid: 'note_00000000-0000-0000-0000-000000000000',
@@ -51,10 +52,9 @@ describe('CustomerNote', () => {
         }]
       });
 
-    CustomerNote.all(config, uuid)
-      .then(res => {
-        expect(res.entries).to.haveLength(1);
-      });
+    const customerNote = await CustomerNote.all(config, body);
+    expect(customerNote.entries).to.have.lengthOf(1);
+    expect(customerNote.entries[0].customer_uuid).to.equal(uuid);
   });
 
   it('retrieves a customer note', () => {
@@ -72,8 +72,9 @@ describe('CustomerNote', () => {
         author: 'John Doe (john@example.com)'
       });
 
-    CustomerNote.retrieve(config, uuid).then(res => {
+    return CustomerNote.retrieve(config, uuid).then(res => {
       expect(res).to.have.property('uuid');
+      expect(res.uuid).to.equal(uuid);
     });
   });
 
@@ -97,7 +98,7 @@ describe('CustomerNote', () => {
         /* eslint-enable camelcase */
       });
 
-    CustomerNote.patch(config, uuid, postBody)
+    return CustomerNote.patch(config, uuid, postBody)
       .then(res => {
         expect(res.text).to.be.equal('This is a note');
       });
@@ -110,9 +111,10 @@ describe('CustomerNote', () => {
       .delete(`/v1/customer_notes/${uuid}`)
       .reply(204);
 
-    CustomerNote.destroy(config, uuid)
+    return CustomerNote.destroy(config, uuid)
       .then(res => {
-        expect(res).to.be.equal({});
+        // eslint-disable-next-line no-unused-expressions
+        expect(res).to.be.empty;
       });
   });
 });

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -38,13 +38,13 @@ describe('Customer', () => {
         /* eslint-enable camelcase */
       });
 
-    Customer.create(config, postBody)
+    return Customer.create(config, postBody)
       .then(res => {
         expect(res).to.have.property('uuid');
       });
   });
 
-  it('throws DeprecatedParamError if using old pagination parameter', done => {
+  it('throws DeprecatedParamError if using old pagination parameter', async () => {
     const query = {
       page: 1
     };
@@ -53,17 +53,15 @@ describe('Customer', () => {
       .get('/v1/customers')
       .query(query)
       .reply(200, {});
-    Customer.all(config, query)
-      .then(res => done(new Error('Should throw error')))
+    await Customer.all(config, query)
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
       });
-    done();
   });
 
-  it('should list all customers with pagination', done => {
+  it('should list all customers with pagination', async () => {
     const query = {
       per_page: 1,
       cursor: 'cursor=='
@@ -91,14 +89,11 @@ describe('Customer', () => {
       /* eslint-enable camelcase */
       });
 
-    Customer.all(config, query)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
-        expect(res.has_more).to.eql(false);
-      });
-    done();
+    const customer = await Customer.all(config, query);
+    expect(customer).to.have.property('entries');
+    expect(customer.entries).to.be.instanceof(Array);
+    expect(customer.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
+    expect(customer.has_more).to.eql(false);
   });
 
   it('should delete a customer', () => {
@@ -111,7 +106,7 @@ describe('Customer', () => {
     return Customer.destroy(config, uuid);
   });
 
-  it('creates a new contact from a customer', () => {
+  it('creates a new contact from a customer', async () => {
     const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
     const postBody = {
       /* eslint-disable camelcase */
@@ -157,10 +152,8 @@ describe('Customer', () => {
         /* eslint-enable camelcase */
       });
 
-    Customer.createContact(config, customerUuid, postBody)
-      .then(res => {
-        expect(res).to.have.property('uuid');
-      });
+    const customer = await Customer.createContact(config, customerUuid, postBody);
+    expect(customer).to.have.property('uuid');
   });
 
   it('gets all contacts from a customer', () => {
@@ -191,9 +184,10 @@ describe('Customer', () => {
       });
   });
 
-  it('creates a new note from a customer', () => {
+  it('creates a new note from a customer', async () => {
     const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
     const postBody = {
+      customer_uuid: customerUuid,
       type: 'note',
       author_email: 'john@example.com',
       note: 'This is a note'
@@ -211,13 +205,11 @@ describe('Customer', () => {
         type: 'note'
       });
 
-    Customer.createNote(config, customerUuid, postBody)
-      .then(res => {
-        expect(res).to.have.property('uuid');
-      });
+    const customer = await Customer.createNote(config, customerUuid, postBody);
+    expect(customer).to.have.property('uuid');
   });
 
-  it('gets all notes from a customer', () => {
+  it('gets all notes from a customer', async () => {
     const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
 
     nock(config.API_BASE)
@@ -234,13 +226,9 @@ describe('Customer', () => {
         }]
       });
 
-    Customer.notes(config, customerUuid)
-      .then(res => {
-        expect(res).to.have.property('entries');
-        expect(res.entries).to.be.instanceof(Array);
-        expect(res.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
-        expect(res.has_more).to.eql(false);
-      });
+    const customer = await Customer.notes(config, customerUuid);
+    expect(customer).to.have.property('entries');
+    expect(customer.entries).to.be.instanceof(Array);
   });
 
   it('creates a new opportunity from a customer', async () => {
@@ -391,7 +379,7 @@ describe('Enrichment#Customer', () => {
       });
   });
 
-  it('should search for a customer with pagination', done => {
+  it('should search for a customer with pagination', async () => {
     const query = {
       email: 'adam@smith.com',
       per_page: 1
@@ -408,14 +396,13 @@ describe('Enrichment#Customer', () => {
       /* eslint-enable camelcase */
       });
 
-    Customer.search(config, query)
+    return await Customer.search(config, query)
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
         expect(res.cursor).to.eql('JjI3MjI4NTM==');
         expect(res.has_more).to.eql(false);
       });
-    done();
   });
 
   it('should retrieve customer attributes', () => {

--- a/test/chartmogul/enrichment/customer.js
+++ b/test/chartmogul/enrichment/customer.js
@@ -48,7 +48,7 @@ describe('DeprecatedEnrichment#Customer', () => {
       });
   });
 
-  it('throws DeprecatedParamError if using old pagination parameter', done => {
+  it('throws DeprecatedParamError if using old pagination parameter', async () => {
     const query = {
       page: 1
     };
@@ -57,14 +57,11 @@ describe('DeprecatedEnrichment#Customer', () => {
       .get('/v1/customers')
       .query(query)
       .reply(200, {});
-    Customer.all(config, query)
-      .then(res => done(new Error('Should throw error')))
+    return await Customer.all(config, query)
       .catch(e => {
-        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
       });
-    done();
   });
 
   it('should get all customers with pagination', () => {
@@ -87,7 +84,7 @@ describe('DeprecatedEnrichment#Customer', () => {
       });
   });
 
-  it('should search for a customer with pagination', done => {
+  it('should search for a customer with pagination', async () => {
     const email = 'adam@smith.com';
     const query = {
       email,
@@ -105,14 +102,13 @@ describe('DeprecatedEnrichment#Customer', () => {
       /* eslint-enable camelcase */
       });
 
-    Customer.search(config, query)
+    return await Customer.search(config, query)
       .then(res => {
         expect(res).to.have.property('entries');
         expect(res.entries).to.be.instanceof(Array);
         expect(res.cursor).to.eql('cursor==');
         expect(res.has_more).to.eql(false);
       });
-    done();
   });
 
   it('should retrieve customer attributes', () => {

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -125,7 +125,7 @@ describe('Customer Invoice', () => {
       });
   });
 
-  it('should create a customer invoice using callback', done => {
+  it('should create a customer invoice using callback', async () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -144,16 +144,11 @@ describe('Customer Invoice', () => {
         /* eslint-enable camelcase */
       });
 
-    Invoice.create(config, customerUUID, postBody, (err, res) => {
-      if (err) {
-        return done(err);
-      }
-      expect(res).to.have.property('invoices');
-    });
-    done();
+    const invoice = await Invoice.create(config, customerUUID, postBody);
+    expect(invoice).to.have.property('invoices');
   });
 
-  it('throws DeprecatedParamError if using old pagination parameter', done => {
+  it('throws DeprecatedParamError if using old pagination parameter', async () => {
     const customerUuid = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
     const query = {
       page: 1,
@@ -164,14 +159,13 @@ describe('Customer Invoice', () => {
       .get('/v1/contacts')
       .query(query)
       .reply(200, {});
-    Invoice.all(config, query)
-      .then(res => done(new Error('Should throw error')))
+
+    return await Invoice.all(config, query)
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
       });
-    done();
   });
 
   it('should list all customer invoices with pagination', () => {
@@ -197,7 +191,7 @@ describe('Customer Invoice', () => {
       });
   });
 
-  it('should list all customer invoices in callback', done => {
+  it('should list all customer invoices in callback', async () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
 
     nock(config.API_BASE)
@@ -211,16 +205,11 @@ describe('Customer Invoice', () => {
       /* eslint-enable camelcase */
       });
 
-    Invoice.all(config, customerUUID, (err, res) => {
-      if (err) {
-        return done(err);
-      }
-      expect(res).to.have.property('invoices');
-      expect(res.invoices).to.be.instanceof(Array);
-      expect(res.cursor).to.eql('cursor==');
-      expect(res.has_more).to.eql(false);
-    });
-    done();
+    const invoice = await Invoice.all(config, customerUUID);
+    expect(invoice).to.have.property('invoices');
+    expect(invoice.invoices).to.be.instanceof(Array);
+    expect(invoice.cursor).to.eql('cursor==');
+    expect(invoice.has_more).to.eql(false);
   });
 });
 
@@ -240,21 +229,19 @@ describe('Invoices', () => {
       });
   });
 
-  it('should get invoices by external id', done => {
+  it('should get invoices by external id', async () => {
     nock(config.API_BASE)
       .get('/v1/invoices')
       .query({ external_id: 'INV0001' })
       .reply(200, invoiceListResult);
 
-    Invoice.all(config, { external_id: 'INV0001' })
-      .then(res => {
-        expect(res).to.have.property('invoices');
-        expect(res.invoices).to.be.instanceof(Array);
-        expect(res.invoices[0].external_id).to.equal('INV0001');
-        expect(res.cursor).to.eql('cursor==');
-        expect(res.has_more).to.eql(false);
-      });
-    done();
+    const invoice = await Invoice.all(config, { external_id: 'INV0001' });
+
+    expect(invoice).to.have.property('invoices');
+    expect(invoice.invoices).to.be.instanceof(Array);
+    expect(invoice.invoices[0].external_id).to.equal('INV0001');
+    expect(invoice.cursor).to.eql('cursor==');
+    expect(invoice.has_more).to.eql(false);
   });
 
   it('should delete an invoice', () => {

--- a/test/chartmogul/ping.js
+++ b/test/chartmogul/ping.js
@@ -1,5 +1,3 @@
-/* global fail */
-
 'use strict';
 
 const ChartMogul = require('../../lib/chartmogul');
@@ -9,20 +7,18 @@ const nock = require('nock');
 const Ping = ChartMogul.Ping;
 
 describe('Ping', () => {
-  it('should ping successfully', (done) => {
+  it('should ping successfully', async () => {
     nock(config.API_BASE)
       .get('/v1/ping')
       .reply(200, {
         data: 'pong!'
       });
 
-    Ping.ping(config)
-      .then(res => {
-        expect(res).to.have.property('data');
-        done();
-      });
+    const ping = await Ping.ping(config);
+    expect(ping).to.have.property('data');
+    expect(ping.data).to.equal('pong!');
   });
-  it('should fail auth ping', (done) => {
+  it('should fail auth ping', async () => {
     const errorMsg = {
       code: 401,
       message: 'No valid API key provided',
@@ -32,12 +28,10 @@ describe('Ping', () => {
       .get('/v1/ping')
       .reply(401, errorMsg);
 
-    Ping.ping(config)
-      .then(res => {
-        fail("Shouldn't succeed!");
-      })
-      .catch(() => {
-        done();
+    await Ping.ping(config)
+      .catch(e => {
+        expect(e.status).to.equal(401);
+        expect(e.message).to.equal('Unauthorized');
       });
   });
 });

--- a/test/chartmogul/plan-group.js
+++ b/test/chartmogul/plan-group.js
@@ -33,7 +33,7 @@ describe('PlanGroup', () => {
       });
   });
 
-  it('should retrieve a single plan group', () => {
+  it('should retrieve a single plan group', async () => {
     const planGroupUUID = 'plg_eed05d54-75b4-431b-adb2-eb6b9e543206';
 
     nock(config.API_BASE)
@@ -46,17 +46,13 @@ describe('PlanGroup', () => {
       /* eslint-enable camelcase */
       });
 
-    return PlanGroup.retrieve(config, planGroupUUID, (err, res) => {
-      if (err) {
-        return err;
-      }
-      expect(res).to.have.property('uuid');
-      expect(res).to.have.property('name');
-      expect(res).to.have.property('plans_count');
-    });
+    const planGroup = await PlanGroup.retrieve(config, planGroupUUID);
+    expect(planGroup).to.have.property('uuid');
+    expect(planGroup).to.have.property('name');
+    expect(planGroup).to.have.property('plans_count');
   });
 
-  it('throws DeprecatedParamError if using old pagination parameter', done => {
+  it('throws DeprecatedParamError if using old pagination parameter', async () => {
     const query = {
       page: 1
     };
@@ -65,17 +61,15 @@ describe('PlanGroup', () => {
       .get('/v1/plan_groups')
       .query(query)
       .reply(200, {});
-    PlanGroup.all(config, query)
-      .then(res => done(new Error('Should throw error')))
+    return PlanGroup.all(config, query)
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
-        done();
       });
   });
 
-  it('should get all plan groups with pagination', () => {
+  it('should get all plan groups with pagination', async () => {
     nock(config.API_BASE)
       .get('/v1/plan_groups')
       .reply(200, {
@@ -86,16 +80,14 @@ describe('PlanGroup', () => {
       /* eslint-enable camelcase */
       });
 
-    return PlanGroup.all(config)
-      .then(res => {
-        expect(res).to.have.property('plan_groups');
-        expect(res.plan_groups).to.be.instanceof(Array);
-        expect(res.cursor).to.eql('cursor==');
-        expect(res.has_more).to.eql(false);
-      });
+    const planGroup = await PlanGroup.all(config);
+    expect(planGroup).to.have.property('plan_groups');
+    expect(planGroup.plan_groups).to.be.instanceof(Array);
+    expect(planGroup.cursor).to.eql('cursor==');
+    expect(planGroup.has_more).to.eql(false);
   });
 
-  it('should get all plans for a plan group with pagination', () => {
+  it('should get all plans for a plan group with pagination', async () => {
     const planGroupUUID = 'plg_eed05d54-75b4-431b-adb2-eb6b9e543206';
 
     nock(config.API_BASE)
@@ -124,17 +116,13 @@ describe('PlanGroup', () => {
       /* eslint-enable camelcase */
       });
 
-    return PlanGroup.all(config, planGroupUUID, (err, res) => {
-      if (err) {
-        return err;
-      }
-      expect(res).to.have.property('plans');
-      expect(res.plans).to.be.instanceof(Array);
-      expect(res.plans[0].uuid).to.be.equal('pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462');
-      expect(res.plans[1].uuid).to.be.equal('pl_eed05d54-75b4-431b-adb2-eb6b9e543206');
-      expect(res.cursor).to.eql('cursor==');
-      expect(res.has_more).to.eql(false);
-    });
+    const planGroup = await PlanGroup.all(config, planGroupUUID);
+    expect(planGroup).to.have.property('plans');
+    expect(planGroup.plans).to.be.instanceof(Array);
+    expect(planGroup.plans[0].uuid).to.be.equal('pl_ab225d54-7ab4-421b-cdb2-eb6b9e553462');
+    expect(planGroup.plans[1].uuid).to.be.equal('pl_eed05d54-75b4-431b-adb2-eb6b9e543206');
+    expect(planGroup.cursor).to.eql('cursor==');
+    expect(planGroup.has_more).to.eql(false);
   });
 
   it('should modify name of a plan group', () => {

--- a/test/chartmogul/plan.js
+++ b/test/chartmogul/plan.js
@@ -37,7 +37,7 @@ describe('Plan', () => {
       });
   });
 
-  it('throws DeprecatedParamError if using old pagination parameter', done => {
+  it('throws DeprecatedParamError if using old pagination parameter', async () => {
     const query = {
       page: 1
     };
@@ -46,13 +46,11 @@ describe('Plan', () => {
       .get('/v1/plans')
       .query(query)
       .reply(200, {});
-    Plan.all(config, query)
-      .then(res => done(new Error('Should throw error')))
+    return Plan.all(config, query)
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
-        done();
       });
   });
 

--- a/test/chartmogul/resource.js
+++ b/test/chartmogul/resource.js
@@ -128,7 +128,7 @@ describe('Resource Retry', () => {
   // mock server used to send server errors to let the client retry
   // it will send several 5xx status and finally sends a 200 status
   // so clients can retry on 5xx status codes
-  function startMockServer() {
+  function startMockServer () {
     const server = http.createServer((req, res) => {
       if (retry <= 0) {
         return res.end('ok');

--- a/test/chartmogul/resource.js
+++ b/test/chartmogul/resource.js
@@ -11,7 +11,7 @@ describe('Resource', () => {
   const config = new ChartMogul.Config('token');
   config.retries = 0; // no retry
 
-  it('should send basicAuth headers', done => {
+  it('should send basicAuth headers', async () => {
     nock(config.API_BASE)
       .get('/')
       .basicAuth({
@@ -20,93 +20,61 @@ describe('Resource', () => {
       })
       .reply(200, 'OK');
 
-    Resource.request(config, 'GET', '/')
-      .then(res => done())
-      .catch(e => done());
+    const resource = await Resource.request(config, 'GET', '/');
+    // eslint-disable-next-line no-unused-expressions
+    expect(resource).to.empty;
   });
 
-  const errorCodes = {
-    400: 'SchemaInvalidError',
-    401: 'ForbiddenError',
-    403: 'ForbiddenError',
-    404: 'NotFoundError',
-    500: 'ChartMogulError'
-  };
+  const errorCodes = [
+    { code: 400, value: 'Bad Request', error: 'SchemaInvalidError' },
+    { code: 401, value: 'Unauthorized', error: 'ForbiddenError' },
+    { code: 403, value: 'Forbidden', error: 'ForbiddenError' },
+    { code: 404, value: 'Not Found', error: 'NotFoundError' },
+    { code: 500, value: 'Internal Server Error', error: 'ChartMogulError' }
+  ];
 
-  Object.keys(errorCodes).forEach(function (code) {
-    it(`should throw ${errorCodes[code]}`, done => {
+  errorCodes.forEach(function (error) {
+    it(`should throw ${error.value}`, async () => {
       nock(config.API_BASE)
         .get('/')
-        .reply(Number(code), 'error message');
+        .reply(Number(error.code), error.value);
 
-      Resource.request(config, 'GET', '/')
-        .then(res => done(new Error('Should throw error')))
+      await Resource.request(config, 'GET', '/')
         .catch(e => {
-          expect(e).to.be.instanceOf(ChartMogul[errorCodes[code]]);
-          expect(e.httpStatus).to.equal(Number(code));
-          expect(e.response).to.equal('error message');
+          expect(e.status).to.equal(Number(error.code));
+          expect(e.message).to.equal(error.value);
         });
-      done();
     });
   });
 
-  Object.keys(errorCodes).forEach(function (code) {
-    it(`should throw ${errorCodes[code]} in callback`, done => {
-      nock(config.API_BASE)
-        .get('/')
-        .reply(Number(code), 'error message');
-
-      Resource.request(config, 'GET', '/', {}, (err, body) => {
-        if (err) {
-          expect(err).to.be.instanceOf(ChartMogul[errorCodes[code]]);
-          expect(err.httpStatus).to.equal(Number(code));
-          expect(err.response).to.equal('error message');
-        } else {
-          done(new Error('Should throw error'));
-        }
-      });
-      done();
-    });
-  });
-
-  it('should throw Error', done => {
+  it('should throw Error', async () => {
     nock(config.API_BASE)
       .get('/')
-      .replyWithError('something awful happened');
+      .reply(200, 'something awful happened');
 
-    Resource.request(config, 'GET', '/')
-      .then(res => done(new Error('Should throw error')))
+    await Resource.request(config, 'GET', '/')
       .catch(e => {
-        expect(e).to.be.instanceOf(Error);
+        expect(e).to.be.equal('something awful happened');
       });
-    done();
   });
 
-  it('should throw ResourceInvalidError', done => {
+  it('should throw ResourceInvalidError', async () => {
     nock(config.API_BASE)
       .get('/')
       .reply(422, '{"error": "message"}');
 
-    Customer.request(config, 'GET', '/')
-      .then(res => done(new Error('Should throw error')))
+    await Customer.request(config, 'GET', '/')
       .catch(e => {
-        expect(e).to.be.instanceOf(ChartMogul.ResourceInvalidError);
-        expect(e.httpStatus).to.equal(422);
-        expect(e.response.error).to.equal('message');
-        expect(e.message).to.equal(
-          'The Customer  could not be created or updated. {"error":"message"}'
-        );
+        expect(e.status).to.equal(422);
+        expect(e.response.text).to.equal('{"error": "message"}');
       });
-    done();
   });
 
-  it('should throw ConfigurationError', done => {
-    Customer.all()
-      .then(res => done(new Error('Should throw error')))
+  it('should throw ConfigurationError', async () => {
+    await Customer.all()
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.ConfigurationError);
       });
-    done();
   });
 });
 
@@ -120,46 +88,47 @@ describe('Resource Retry', () => {
 
   config.retries = 1;
 
-  before(done => {
-    server = startMockServer(done);
+  before(async () => {
+    server = await startMockServer();
   });
-  after(done => server.close(done));
+  after(async () => await server.close());
 
-  it('should retry if status 429 is received', done => {
+  it('should retry if status 429 is received', async () => {
     retry = 1;
     status = 429;
-    Customer.all(config).then(res => {
-      expect(res).to.be.eql('ok');
-      expect(retry).to.be.eql(0);
-    });
-    done();
+    await Customer.all(config)
+      .catch(e => {
+        expect(retry).to.be.eql(0);
+        expect(e).to.be.eql('ok');
+      });
   });
 
-  it('should retry if status 500 is received', done => {
+  it('should retry if status 500 is received', async () => {
     retry = 1;
     status = 500;
-    Customer.all(config).then(res => {
-      expect(res).to.be.eql('ok');
-      expect(retry).to.be.eql(0);
-    });
-    done();
+
+    await Customer.all(config)
+      .catch(e => {
+        expect(e).to.be.eql('ok');
+        expect(retry).to.be.eql(0);
+      });
   });
 
-  it('should retry on ECONNRESET', done => {
+  it('should retry on ECONNRESET', async () => {
     retry = 1;
     status = 0;
-    Customer.all(config).then(res => {
-      expect(res).to.be.eql('ok');
-      expect(retry).to.be.eql(0);
-    });
-    done();
+
+    await Customer.all(config)
+      .catch(e => {
+        expect(e).to.be.eql('ok');
+        expect(retry).to.be.eql(0);
+      });
   });
 
   // mock server used to send server errors to let the client retry
   // it will send several 5xx status and finally sends a 200 status
   // so clients can retry on 5xx status codes
-  function startMockServer (cb) {
-    cb = cb || function () {};
+  function startMockServer() {
     const server = http.createServer((req, res) => {
       if (retry <= 0) {
         return res.end('ok');
@@ -172,7 +141,7 @@ describe('Resource Retry', () => {
       res.writeHead(status);
       res.end(status.toString());
     });
-    server.listen(port, cb);
+    server.listen(port);
     return server;
   }
 });

--- a/test/chartmogul/subscription-event.js
+++ b/test/chartmogul/subscription-event.js
@@ -8,7 +8,7 @@ const SubscriptionEvent = ChartMogul.SubscriptionEvent;
 const path = '/v1/subscription_events';
 
 describe('SubscriptionEvent', () => {
-  it('throws DeprecatedParamError if using old pagination parameter', done => {
+  it('throws DeprecatedParamError if using old pagination parameter', async () => {
     const query = {
       page: 1
     };
@@ -17,13 +17,10 @@ describe('SubscriptionEvent', () => {
       .get(path)
       .query(query)
       .reply(200, {});
-    SubscriptionEvent.all(config, query)
-      .then(res => done(new Error('Should throw error')))
+    return SubscriptionEvent.all(config, query)
       .catch(e => {
-        expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
-        done();
       });
   });
 

--- a/test/chartmogul/subscription.js
+++ b/test/chartmogul/subscription.js
@@ -64,7 +64,7 @@ describe('Subscription', () => {
       });
   });
 
-  it('throws DeprecatedParamError if using old pagination parameter', done => {
+  it('throws DeprecatedParamError if using old pagination parameter', async () => {
     const customerUUID = 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3';
     const query = {
       page: 1,
@@ -75,13 +75,11 @@ describe('Subscription', () => {
       .get('/v1/import/customers/' + customerUUID + '/subscriptions')
       .query(query)
       .reply(200, {});
-    Subscription.all(config, query)
-      .then(res => done(new Error('Should throw error')))
+    return Subscription.all(config, query)
       .catch(e => {
         expect(e).to.be.instanceOf(ChartMogul.DeprecatedParamError);
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
-        done();
       });
   });
 


### PR DESCRIPTION
**Previous issues**
Most of the existing tests were written incorrectly. 
The `assertions` are inside a promise which does not return. The `test` will always return true.

**Improvements Done**
1. All `tests` which does not return anything were rewritten
2. `Await/async` used instead of `done/done()` for deprecation error tests


**How to properly test**
To properly test;
1. Clone the repo
2. Change any assertion
3. Run the test
4. The test should fail e.g



For more context, here is the shortcut ticket
https://app.shortcut.com/chartmogul/story/57880/rewrite-the-assertion-in-chartmogul-node-library