### PR TITLE
Add Tasks API support to Node Client [sc-66750]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [3.7.0] - 2025-04-25
+- Adds support for Tasks (https://dev.chartmogul.com/reference/tasks)
+
 ## [3.6.0] - 2025-03-18
 - Adds support for disconnecting subscriptions
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ ChartMogul.Customer.create(config, data, (err, res) => {
 
 Available methods in Import API:
 
-#### [Data Sources](https://dev.chartmogul.com/docs/data-sources)
+#### [Data Sources](https://dev.chartmogul.com/reference/sources/)
 
 ```js
 ChartMogul.DataSource.create(config, data)
@@ -108,7 +108,7 @@ ChartMogul.DataSource.all(config, query)
 ChartMogul.DataSource.destroy(config, dataSourceUuid)
 ```
 
-#### [Customers](https://dev.chartmogul.com/docs/customers)
+#### [Customers](https://dev.chartmogul.com/reference/customers/)
 
 ```js
 ChartMogul.Customer.create(config, data)
@@ -135,9 +135,12 @@ ChartMogul.Customer.createNote(config, customerUuid, data)
 
 ChartMogul.Customer.opportunities(config, customerUuid, { per_page: 10, cursor: 'cursor==' })
 ChartMogul.Customer.createOpportunity(config, customerUuid, data)
+
+ChartMogul.Customer.tasks(config, customerUuid, { per_page: 10, cursor: 'cursor==' })
+ChartMogul.Customer.createTask(config, customerUuid, data)
 ```
 
-#### [Contacts](https://dev.chartmogul.com/docs/contacts)
+#### [Contacts](https://dev.chartmogul.com/reference/contacts/)
 
 ```js
 ChartMogul.Contact.create(config, data)
@@ -149,7 +152,7 @@ ChartMogul.Contact.all(config, { per_page: 10, cursor: 'cursor==' })
 
 ```
 
-#### [Customer Notes](https://dev.chartmogul.com/docs/customer_notes)
+#### [Customer Notes](https://dev.chartmogul.com/reference/notes-and-call-logs/)
 
 ```js
 ChartMogul.CustomerNote.create(config, data)
@@ -160,7 +163,7 @@ ChartMogul.CustomerNote.all(config, { per_page: 10, cursor: 'cursor==', customer
 
 ```
 
-#### [Opportunities](https://dev.chartmogul.com/docs/opportunities)
+#### [Opportunities](https://dev.chartmogul.com/reference/opportunities/)
 
 ```js
 ChartMogul.Opportunity.create(config, data)
@@ -170,8 +173,18 @@ ChartMogul.Opportunity.destroy(config, opportunityUuid)
 ChartMogul.Opportunity.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
 ```
 
+#### [Tasks](https://dev.chartmogul.com/reference/tasks/)
 
-#### [Plans](https://dev.chartmogul.com/docs/plans)
+```js
+ChartMogul.Task.create(config, data)
+ChartMogul.Task.retrieve(config, taskUuid)
+ChartMogul.Task.patch(config, taskUuid, data)
+ChartMogul.Task.destroy(config, taskUuid)
+ChartMogul.Task.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
+```
+
+
+#### [Plans](https://dev.chartmogul.com/reference/plans/)
 
 ```js
 ChartMogul.Plan.create(config, data)
@@ -181,7 +194,7 @@ ChartMogul.Plan.destroy(config, uuid)
 ChartMogul.Plan.all(config, query)
 ```
 
-#### [Plan Groups](https://dev.chartmogul.com/docs/plan_groups)
+#### [Plan Groups](https://dev.chartmogul.com/reference/plan-groups/)
 
 ```js
 ChartMogul.PlanGroup.create(config, data)
@@ -192,7 +205,7 @@ ChartMogul.PlanGroup.all(config, query)
 ChartMogul.PlanGroup.all(config, planGroupUuid, query)
 ```
 
-#### [Subscriptions](https://dev.chartmogul.com/docs/subscriptions)
+#### [Subscriptions](https://dev.chartmogul.com/reference/subscriptions/)
 
 ```js
 ChartMogul.Subscription.all(config, customerUuid, query)
@@ -200,7 +213,7 @@ ChartMogul.Subscription.cancel(config, subscriptionUuid, { cancelled_at: '' })
 ChartMogul.Subscription.modify(config, subscriptionUuid, { cancellation_dates: [] })
 ```
 
-#### [Invoices](https://dev.chartmogul.com/docs/invoices)
+#### [Invoices](https://dev.chartmogul.com/reference/invoices/)
 
 ```js
 ChartMogul.Invoice.create(config, customerUuid, data)
@@ -211,13 +224,13 @@ ChartMogul.Invoice.all(config, query)
 ChartMogul.Invoice.destroy_all(config, dataSourceUuid, customerUuid)
 ```
 
-#### [Transactions](https://dev.chartmogul.com/docs/transactions)
+#### [Transactions](https://dev.chartmogul.com/reference/transactions/)
 
 ```js
 ChartMogul.Transaction.create(config, invoiceUuid, data)
 ```
 
-#### [Subscription events](https://dev.chartmogul.com/reference/subscription-events)
+#### [Subscription events](https://dev.chartmogul.com/reference/subscription-events/)
 
 ```js
 ChartMogul.SubscriptionEvent.create(config, {
@@ -248,19 +261,19 @@ ChartMogul.SubscriptionEvent.all(config, query)
 
 Available methods in Enrichment API:
 
-#### [Customers](https://dev.chartmogul.com/reference/customers-1)
+#### [Customers](https://dev.chartmogul.com/reference/customers/)
 
 ```js
 ChartMogul.Customer.search(config, { email: 'bob@example.com' })
 ```
 
-#### [Customer Attributes](https://dev.chartmogul.com/docs/customer-attributes)
+#### [Customer Attributes](https://dev.chartmogul.com/reference/customers/attributes/)
 
 ```js
 ChartMogul.Customer.attributes(config, customerUuid)
 ```
 
-#### [Tags](https://dev.chartmogul.com/docs/tags)
+#### [Tags](https://dev.chartmogul.com/reference/customers/tags/)
 
 ```js
 ChartMogul.Tag.add(config, customerUuid, {
@@ -275,7 +288,7 @@ ChartMogul.Tag.remove(config, customerUuid, {
 });
 ```
 
-#### [Custom Attributes](https://dev.chartmogul.com/docs/custom-attributes)
+#### [Custom Attributes](https://dev.chartmogul.com/reference/customers/attributes/)
 
 ```js
 ChartMogul.CustomAttribute.add(config, customerUuid, {
@@ -300,7 +313,7 @@ ChartMogul.CustomAttribute.remove(config, customerUuid, {
 });
 ```
 
-### [Metrics API](https://dev.chartmogul.com/docs/introduction-metrics-api)
+### [Metrics API](https://dev.chartmogul.com/reference/metrics/)
 
 Available methods in Metrics API:
 

--- a/lib/chartmogul.js
+++ b/lib/chartmogul.js
@@ -11,6 +11,7 @@ const Opportunity = require('./chartmogul/opportunity');
 const Plan = require('./chartmogul/plan');
 const PlanGroup = require('./chartmogul/plan-group');
 const Ping = require('./chartmogul/ping');
+const Task = require('./chartmogul/task');
 
 const Invoice = require('./chartmogul/invoice');
 const Subscription = require('./chartmogul/subscription');
@@ -46,6 +47,7 @@ const ChartMogul = {
   Subscription,
   SubscriptionEvent,
   Tag,
+  Task,
   Transaction,
   Account
 };

--- a/lib/chartmogul/customer.js
+++ b/lib/chartmogul/customer.js
@@ -51,14 +51,14 @@ class Customer extends Resource {
     return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerId }, callback);
   }
 
-  static tasks (config, customerId, params, callback) {
+  static tasks (config, customerUuid, params, callback) {
     const path = util.expandPath(Task.path, []);
-    return Resource.request(config, 'GET', path, { ...params, customer_uuid: customerId }, callback);
+    return Resource.request(config, 'GET', path, { ...params, customer_uuid: customerUuid }, callback);
   }
 
-  static createTask (config, customerId, params, callback) {
+  static createTask (config, customerUuid, params, callback) {
     const path = util.expandPath(Task.path, []);
-    return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerId }, callback);
+    return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerUuid }, callback);
   }
 }
 

--- a/lib/chartmogul/customer.js
+++ b/lib/chartmogul/customer.js
@@ -4,6 +4,7 @@ const Resource = require('./resource');
 const util = require('./util');
 const CustomerNote = require('./customer-note');
 const Opportunity = require('./opportunity');
+const Task = require('./task');
 
 class Customer extends Resource {
   static get path () {
@@ -47,6 +48,16 @@ class Customer extends Resource {
 
   static createOpportunity (config, customerId, params, callback) {
     const path = util.expandPath(Opportunity.path, []);
+    return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerId }, callback);
+  }
+
+  static tasks (config, customerId, params, callback) {
+    const path = util.expandPath(Task.path, []);
+    return Resource.request(config, 'GET', path, { ...params, customer_uuid: customerId }, callback);
+  }
+
+  static createTask (config, customerId, params, callback) {
+    const path = util.expandPath(Task.path, []);
     return Resource.request(config, 'POST', path, { ...params, customer_uuid: customerId }, callback);
   }
 }

--- a/lib/chartmogul/task.js
+++ b/lib/chartmogul/task.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Resource = require('./resource');
+
+class Task extends Resource {
+  static get path () {
+    return '/v1/tasks{/taskUuid}';
+  }
+}
+
+module.exports = Task;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "3.5.0",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "3.5.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "retry": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/customer.js
+++ b/test/chartmogul/customer.js
@@ -313,6 +313,66 @@ describe('Customer', () => {
     expect(opportunities.cursor).to.eql('MjAyMy0wMy0xM1QxMjowMTozMi44MD==');
     expect(opportunities.has_more).to.eql(false);
   });
+
+  it('creates a new task for a customer', async () => {
+    const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
+    const postBody = {
+      customer_uuid: customerUuid,
+      assignee: 'customer@example.com',
+      task_details: 'This is some task details text.',
+      due_date: '2025-04-30T00:00:00Z',
+      completed_at: '2025-04-20T00:00:00Z'
+    };
+
+    nock(config.API_BASE)
+      .post('/v1/tasks', postBody)
+      .reply(200, {
+        uuid: '00000000-0000-0000-0000-000000000000',
+        customer_uuid: customerUuid,
+        assignee: 'customer@example.com',
+        task_details: 'This is some task details text.',
+        due_date: '2025-04-30T00:00:00Z',
+        completed_at: '2025-04-20T00:00:00Z',
+        created_at: '2025-04-01T12:00:00.000Z',
+        updated_at: '2025-04-01T12:00:00.000Z'
+      });
+
+    const task = await Customer.createTask(config, customerUuid, postBody);
+    expect(task.uuid).to.equal('00000000-0000-0000-0000-000000000000');
+    expect(task.customer_uuid).to.equal(customerUuid);
+    expect(task.assignee).to.equal('customer@example.com');
+    expect(task.task_details).to.equal('This is some task details text.');
+    expect(task.due_date).to.equal('2025-04-30T00:00:00Z');
+    expect(task.completed_at).to.equal('2025-04-20T00:00:00Z');
+  });
+
+  it('gets all tasks for a customer', async () => {
+    const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
+
+    nock(config.API_BASE)
+      .get(`/v1/tasks?customer_uuid=${customerUuid}`)
+      .reply(200, {
+        entries: [{
+          uuid: '00000000-0000-0000-0000-000000000000',
+          customer_uuid: customerUuid,
+          assignee: 'customer@example.com',
+          task_details: 'This is some task details text.',
+          due_date: '2025-04-30T00:00:00Z',
+          completed_at: '2025-04-20T00:00:00Z',
+          created_at: '2025-04-01T12:00:00.000Z',
+          updated_at: '2025-04-01T12:00:00.000Z'
+        }],
+        cursor: 'OjAyMy0wOy0xM1QxMkowMTozMi64NF==',
+        has_more: false
+      });
+
+    const tasks = await Customer.tasks(config, customerUuid);
+    expect(tasks).to.have.property('entries');
+    expect(tasks.entries).to.be.instanceof(Array);
+    expect(tasks.entries).to.have.lengthOf(1);
+    expect(tasks.cursor).to.equal('OjAyMy0wOy0xM1QxMkowMTozMi64NF==');
+    expect(tasks.has_more).to.equal(false);
+  });
 });
 
 /** Suite that originally belonged in the Enrichment module.

--- a/test/chartmogul/task.js
+++ b/test/chartmogul/task.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const ChartMogul = require('../../lib/chartmogul');
+const config = new ChartMogul.Config('token');
+const expect = require('chai').expect;
+const nock = require('nock');
+const Task = ChartMogul.Task;
+
+describe('Task', () => {
+  it('creates a task', async () => {
+    const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
+    const postBody = {
+      customer_uuid: customerUuid,
+      assignee: 'customer@example.com',
+      task_details: 'This is some task details text.',
+      due_date: '2025-04-30T00:00:00Z',
+      completed_at: '2025-04-20T00:00:00Z'
+    };
+
+    nock(config.API_BASE)
+      .post('/v1/tasks', postBody)
+      .reply(200, {
+        uuid: '00000000-0000-0000-0000-000000000000',
+        customer_uuid: customerUuid,
+        assignee: 'customer@example.com',
+        task_details: 'This is some task details text.',
+        due_date: '2025-04-30T00:00:00Z',
+        completed_at: '2025-04-20T00:00:00Z',
+        created_at: '2025-04-01T12:00:00.000Z',
+        updated_at: '2025-04-01T12:00:00.000Z'
+      });
+
+    const task = await Task.create(config, postBody);
+    expect(task.uuid).to.equal('00000000-0000-0000-0000-000000000000');
+    expect(task.customer_uuid).to.equal(customerUuid);
+    expect(task.assignee).to.equal('customer@example.com');
+    expect(task.task_details).to.equal('This is some task details text.');
+    expect(task.due_date).to.equal('2025-04-30T00:00:00Z');
+    expect(task.completed_at).to.equal('2025-04-20T00:00:00Z');
+  });
+
+  it('lists all tasks', async () => {
+    const customerUuid = 'cus_00000000-0000-0000-0000-000000000000';
+    const body = { customer_uuid: customerUuid, per_page: 10, cursor: 'cursor==' };
+
+    nock(config.API_BASE)
+      .get(`/v1/tasks?customer_uuid=${customerUuid}&per_page=10&cursor=cursor==`)
+      .reply(200, {
+        entries: [{
+          uuid: '00000000-0000-0000-0000-000000000000',
+          customer_uuid: customerUuid,
+          assignee: 'customer@example.com',
+          task_details: 'This is some task details text.',
+          due_date: '2025-04-30T00:00:00Z',
+          completed_at: '2025-04-20T00:00:00Z',
+          created_at: '2025-04-01T12:00:00.000Z',
+          updated_at: '2025-04-01T12:00:00.000Z'
+        }]
+      });
+
+    const tasks = await Task.all(config, body);
+    expect(tasks).to.have.property('entries');
+    expect(tasks.entries).to.be.instanceof(Array);
+    expect(tasks.entries).to.have.lengthOf(1);
+    expect(tasks.entries[0].uuid).to.equal('00000000-0000-0000-0000-000000000000');
+    expect(tasks.entries[0].customer_uuid).to.equal(customerUuid);
+    expect(tasks.entries[0].assignee).to.equal('customer@example.com');
+    expect(tasks.entries[0].task_details).to.equal('This is some task details text.');
+    expect(tasks.entries[0].due_date).to.equal('2025-04-30T00:00:00Z');
+    expect(tasks.entries[0].completed_at).to.equal('2025-04-20T00:00:00Z');
+  });
+
+  it('retrieves a task', async () => {
+    const uuid = '00000000-0000-0000-0000-000000000000';
+
+    nock(config.API_BASE)
+      .get(`/v1/tasks/${uuid}`)
+      .reply(200, {
+        uuid,
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        assignee: 'customer@example.com',
+        task_details: 'This is some task details text.',
+        due_date: '2025-04-30T00:00:00Z',
+        completed_at: '2025-04-20T00:00:00Z',
+        created_at: '2025-04-01T12:00:00.000Z',
+        updated_at: '2025-04-01T12:00:00.000Z'
+      });
+
+    const task = await Task.retrieve(config, uuid);
+    expect(task.uuid).to.equal(uuid);
+    expect(task.customer_uuid).to.equal('cus_00000000-0000-0000-0000-000000000000');
+    expect(task.assignee).to.equal('customer@example.com');
+    expect(task.task_details).to.equal('This is some task details text.');
+    expect(task.due_date).to.equal('2025-04-30T00:00:00Z');
+    expect(task.completed_at).to.equal('2025-04-20T00:00:00Z');
+  });
+
+  it('updates a task', async () => {
+    const uuid = '00000000-0000-0000-0000-000000000000';
+    const patchBody = {
+      task_details: 'This is some other task details text.'
+    };
+
+    nock(config.API_BASE)
+      .patch(`/v1/tasks/${uuid}`, patchBody)
+      .reply(200, {
+        uuid,
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        assignee: 'customer@example.com',
+        task_details: 'This is some other task details text.',
+        due_date: '2025-04-30T00:00:00Z',
+        completed_at: '2025-04-20T00:00:00Z',
+        created_at: '2025-04-01T12:00:00.000Z',
+        updated_at: '2025-04-01T12:00:00.000Z'
+      });
+
+    const task = await Task.patch(config, uuid, patchBody);
+    expect(task.uuid).to.equal(uuid);
+    expect(task.customer_uuid).to.equal('cus_00000000-0000-0000-0000-000000000000');
+    expect(task.assignee).to.equal('customer@example.com');
+    expect(task.task_details).to.equal('This is some other task details text.');
+    expect(task.due_date).to.equal('2025-04-30T00:00:00Z');
+    expect(task.completed_at).to.equal('2025-04-20T00:00:00Z');
+  });
+
+  it('deletes a task', async () => {
+    const uuid = '00000000-0000-0000-0000-000000000000';
+
+    nock(config.API_BASE).delete(`/v1/tasks/${uuid}`).reply(204);
+
+    const task = await Task.destroy(config, uuid);
+    // eslint-disable-next-line no-unused-expressions
+    expect(task).to.be.empty;
+    expect(task).to.be.instanceof(Object);
+  });
+});


### PR DESCRIPTION
This PR adds support for the Tasks API to the SDK.

The spec for this project can be found [here](https://www.notion.so/chartmogul/API-for-Tasks-c87a8c8de97d495a92bf7266c49ff6ec).

I'll bump the version in a separate release PR.

### Customer Additions

```js
ChartMogul.Customer.tasks(config, customerUuid, { per_page: 10, cursor: 'cursor==' })
ChartMogul.Customer.createTask(config, customerUuid, data)
```

### Task Additions

```js
ChartMogul.Task.create(config, data)
ChartMogul.Task.retrieve(config, taskUuid)
ChartMogul.Task.patch(config, taskUuid, data)
ChartMogul.Task.destroy(config, taskUuid)
ChartMogul.Task.all(config, { per_page: 10, cursor: 'cursor==', customer_uuid: customerUuid})
```