### PR TITLE
Add requests timeout and retry on timeout

### DIFF
--- a/lib/chartmogul/util/retry.js
+++ b/lib/chartmogul/util/retry.js
@@ -22,7 +22,8 @@ const RETRIABLE_ERRORS = [
   'ECONNREFUSED',
   'EHOSTUNREACH',
   'EPIPE',
-  'EAI_AGAIN'
+  'EAI_AGAIN',
+  'ECONNABORTED'
 ];
 
 function retryOnNetworkError (err) {
@@ -49,6 +50,7 @@ module.exports = function retryRequest (retries, options, cb) {
     const request = superagent(options.method || 'get', requestUrl)
       .auth(options.auth.user, options.auth.pass)
       .set(options.headers)
+      .timeout({ response: 30000, deadline: 120000 })
       .query(options.qs)
       .send(options.body);
 


### PR DESCRIPTION
By default the [NPM `superagent`](https://www.npmjs.com/package/superagent) http library does not timeout, and it waits indefinitely for a response.

I configured it to timeout after 30 seconds (the same amount that all other SDKs do) and retry on the timeout error. 