### PR TITLE
Add External ID Field to Contact Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning].
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [3.11.0] - 2026-03-16
+- Add `external_id` key to Contact model
+
 ## [3.10.0] - 2026-01-29
 - Add HTTP requests 30 seconds timeout, 120 seconds deadline and retry on timeout
 

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -4,6 +4,13 @@ const errors = require('./errors');
 const util = require('./util');
 const Config = require('./config');
 
+// Explicitly strips undefined fields; null is preserved so callers can
+// intentionally clear a field (e.g. external_id: null).
+function stripUndefined (obj) {
+  if (!obj || typeof obj !== 'object') return obj;
+  return JSON.parse(JSON.stringify(obj));
+}
+
 // HTTP verb mapping
 const mappings = {
   all: 'GET',
@@ -53,7 +60,7 @@ class Resource {
       }
 
       const qs = method === 'GET' ? data : {};
-      const body = method === 'GET' ? {} : data;
+      const body = method === 'GET' ? {} : stripUndefined(data);
 
       const options = {
         qs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
         "retry": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {

--- a/test/chartmogul/contact.js
+++ b/test/chartmogul/contact.js
@@ -13,6 +13,7 @@ describe('Contact', () => {
       customer_uuid: 'cus_919d5d7c-9e23-11ed-a936-97fbf69ba02b',
       data_source_uuid: 'ds_87832fac-ab61-11ec-a8d8-6fb18044a151',
       data_source_customer_external_id: 'scus_606e14228cff7d9db01be55f4e32e5e4',
+      external_id: 'contact_external_id_001',
       first_name: 'First name',
       last_name: 'Last name',
       position: 9,
@@ -37,6 +38,7 @@ describe('Contact', () => {
         customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
         data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
         data_source_customer_external_id: 'external_001',
+        external_id: 'contact_external_id_001',
         first_name: 'First name',
         last_name: 'Last name',
         position: 9,
@@ -55,6 +57,109 @@ describe('Contact', () => {
 
     const contact = await Contact.create(config, postBody);
     expect(contact).to.have.property('uuid');
+  });
+
+  it('creates a new contact with external_id as null', async () => {
+    const postBody = {
+      /* eslint-disable camelcase */
+      customer_uuid: 'cus_919d5d7c-9e23-11ed-a936-97fbf69ba02b',
+      data_source_uuid: 'ds_87832fac-ab61-11ec-a8d8-6fb18044a151',
+      data_source_customer_external_id: 'scus_606e14228cff7d9db01be55f4e32e5e4',
+      external_id: null,
+      first_name: 'First name',
+      last_name: 'Last name',
+      position: 9,
+      title: 'Title',
+      email: 'test@example.com',
+      phone: '+1234567890',
+      linked_in: 'https://linkedin.com/not_found',
+      twitter: 'https://twitter.com/not_found',
+      notes: 'Heading\nBody\nFooter',
+      custom: [
+        { key: 'Booleanz', value: false },
+        { key: 'MyIntegerAttribute', value: 123 }
+      ]
+      /* eslint-enable camelcase */
+    };
+
+    nock(config.API_BASE)
+      .post('/v1/contacts', postBody)
+      .reply(200, {
+        /* eslint-disable camelcase */
+        uuid: 'con_00000000-0000-0000-0000-000000000000',
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
+        data_source_customer_external_id: 'external_001',
+        external_id: null,
+        first_name: 'First name',
+        last_name: 'Last name',
+        position: 9,
+        title: 'Title',
+        email: 'test@example.com',
+        phone: '+1234567890',
+        linked_in: 'https://linkedin.com/not_found',
+        twitter: 'https://twitter.com/not_found',
+        notes: 'Heading\nBody\nFooter',
+        custom: {
+          MyStringAttribute: 'Test',
+          MyIntegerAttribute: 123
+        }
+        /* eslint-enable camelcase */
+      });
+
+    const contact = await Contact.create(config, postBody);
+    expect(contact.external_id).to.equal(null);
+  });
+
+  it('creates a new contact without external_id', async () => {
+    const postBody = {
+      /* eslint-disable camelcase */
+      customer_uuid: 'cus_919d5d7c-9e23-11ed-a936-97fbf69ba02b',
+      data_source_uuid: 'ds_87832fac-ab61-11ec-a8d8-6fb18044a151',
+      data_source_customer_external_id: 'scus_606e14228cff7d9db01be55f4e32e5e4',
+      first_name: 'First name',
+      last_name: 'Last name',
+      position: 9,
+      title: 'Title',
+      email: 'test@example.com',
+      phone: '+1234567890',
+      linked_in: 'https://linkedin.com/not_found',
+      twitter: 'https://twitter.com/not_found',
+      notes: 'Heading\nBody\nFooter',
+      custom: [
+        { key: 'Booleanz', value: false },
+        { key: 'MyIntegerAttribute', value: 123 }
+      ]
+      /* eslint-enable camelcase */
+    };
+
+    nock(config.API_BASE)
+      .post('/v1/contacts', postBody)
+      .reply(200, {
+        /* eslint-disable camelcase */
+        uuid: 'con_00000000-0000-0000-0000-000000000000',
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
+        data_source_customer_external_id: 'external_001',
+        external_id: null,
+        first_name: 'First name',
+        last_name: 'Last name',
+        position: 9,
+        title: 'Title',
+        email: 'test@example.com',
+        phone: '+1234567890',
+        linked_in: 'https://linkedin.com/not_found',
+        twitter: 'https://twitter.com/not_found',
+        notes: 'Heading\nBody\nFooter',
+        custom: {
+          MyStringAttribute: 'Test',
+          MyIntegerAttribute: 123
+        }
+        /* eslint-enable camelcase */
+      });
+
+    const contact = await Contact.create(config, postBody);
+    expect(contact.external_id).to.equal(null);
   });
 
   it('should list all contacts with pagination', async () => {
@@ -118,6 +223,7 @@ describe('Contact', () => {
         customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
         data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
         customer_external_id: 'external_001',
+        external_id: 'contact_external_id_001',
         first_name: 'First name',
         last_name: 'Last name',
         position: 9,
@@ -142,23 +248,47 @@ describe('Contact', () => {
     const contactUuid = 'con_00000000-0000-0000-0000-000000000000';
 
     /* eslint-disable camelcase */
-    const postBody = { email: 'test2@example.com' };
+    const patchBody = { email: 'test2@example.com', external_id: 'contact_external_id_002' };
     /* eslint-enable camelcase */
 
     nock(config.API_BASE)
-      .patch(`/v1/contacts/${contactUuid}`, postBody)
+      .patch(`/v1/contacts/${contactUuid}`, patchBody)
       .reply(200, {
         /* eslint-disable camelcase */
         uuid: contactUuid,
         customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
         data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
         customer_external_id: 'external_001',
-        email: 'test2@example.com'
+        email: 'test2@example.com',
+        external_id: 'contact_external_id_002'
         /* eslint-enable camelcase */
       });
 
-    const contact = await Contact.modify(config, contactUuid, postBody);
+    const contact = await Contact.modify(config, contactUuid, patchBody);
     expect(contact.email).to.be.equal('test2@example.com');
+    expect(contact.external_id).to.be.equal('contact_external_id_002');
+  });
+
+  it('updates a contact with external_id as null', async () => {
+    const contactUuid = 'con_00000000-0000-0000-0000-000000000000';
+
+    /* eslint-disable camelcase */
+    const patchBody = { external_id: null };
+    /* eslint-enable camelcase */
+
+    nock(config.API_BASE)
+      .patch(`/v1/contacts/${contactUuid}`, patchBody)
+      .reply(200, {
+        /* eslint-disable camelcase */
+        uuid: contactUuid,
+        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
+        data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
+        external_id: null
+        /* eslint-enable camelcase */
+      });
+
+    const contact = await Contact.modify(config, contactUuid, patchBody);
+    expect(contact.external_id).to.equal(null);
   });
 
   it('deletes a contact', async () => {

--- a/test/chartmogul/contact.js
+++ b/test/chartmogul/contact.js
@@ -82,33 +82,14 @@ describe('Contact', () => {
       /* eslint-enable camelcase */
     };
 
+    let requestBody;
     nock(config.API_BASE)
-      .post('/v1/contacts', postBody)
-      .reply(200, {
-        /* eslint-disable camelcase */
-        uuid: 'con_00000000-0000-0000-0000-000000000000',
-        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
-        data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
-        data_source_customer_external_id: 'external_001',
-        external_id: null,
-        first_name: 'First name',
-        last_name: 'Last name',
-        position: 9,
-        title: 'Title',
-        email: 'test@example.com',
-        phone: '+1234567890',
-        linked_in: 'https://linkedin.com/not_found',
-        twitter: 'https://twitter.com/not_found',
-        notes: 'Heading\nBody\nFooter',
-        custom: {
-          MyStringAttribute: 'Test',
-          MyIntegerAttribute: 123
-        }
-        /* eslint-enable camelcase */
-      });
+      .post('/v1/contacts', body => { requestBody = body; return true; })
+      .reply(200, { uuid: 'con_00000000-0000-0000-0000-000000000000' });
 
-    const contact = await Contact.create(config, postBody);
-    expect(contact.external_id).to.equal(null);
+    await Contact.create(config, postBody);
+    // eslint-disable-next-line no-unused-expressions
+    expect(requestBody).to.have.property('external_id').that.is.null;
   });
 
   it('creates a new contact without external_id', async () => {
@@ -133,33 +114,13 @@ describe('Contact', () => {
       /* eslint-enable camelcase */
     };
 
+    let requestBody;
     nock(config.API_BASE)
-      .post('/v1/contacts', postBody)
-      .reply(200, {
-        /* eslint-disable camelcase */
-        uuid: 'con_00000000-0000-0000-0000-000000000000',
-        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
-        data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
-        data_source_customer_external_id: 'external_001',
-        external_id: null,
-        first_name: 'First name',
-        last_name: 'Last name',
-        position: 9,
-        title: 'Title',
-        email: 'test@example.com',
-        phone: '+1234567890',
-        linked_in: 'https://linkedin.com/not_found',
-        twitter: 'https://twitter.com/not_found',
-        notes: 'Heading\nBody\nFooter',
-        custom: {
-          MyStringAttribute: 'Test',
-          MyIntegerAttribute: 123
-        }
-        /* eslint-enable camelcase */
-      });
+      .post('/v1/contacts', body => { requestBody = body; return true; })
+      .reply(200, { uuid: 'con_00000000-0000-0000-0000-000000000000' });
 
-    const contact = await Contact.create(config, postBody);
-    expect(contact.external_id).to.equal(null);
+    await Contact.create(config, postBody);
+    expect(requestBody).to.not.have.property('external_id');
   });
 
   it('should list all contacts with pagination', async () => {
@@ -276,19 +237,14 @@ describe('Contact', () => {
     const patchBody = { external_id: null };
     /* eslint-enable camelcase */
 
+    let requestBody;
     nock(config.API_BASE)
-      .patch(`/v1/contacts/${contactUuid}`, patchBody)
-      .reply(200, {
-        /* eslint-disable camelcase */
-        uuid: contactUuid,
-        customer_uuid: 'cus_00000000-0000-0000-0000-000000000000',
-        data_source_uuid: 'ds_00000000-0000-0000-0000-000000000000',
-        external_id: null
-        /* eslint-enable camelcase */
-      });
+      .patch(`/v1/contacts/${contactUuid}`, body => { requestBody = body; return true; })
+      .reply(200, { uuid: contactUuid });
 
-    const contact = await Contact.modify(config, contactUuid, patchBody);
-    expect(contact.external_id).to.equal(null);
+    await Contact.modify(config, contactUuid, patchBody);
+    // eslint-disable-next-line no-unused-expressions
+    expect(requestBody).to.have.property('external_id').that.is.null;
   });
 
   it('deletes a contact', async () => {

--- a/test/chartmogul/resource.js
+++ b/test/chartmogul/resource.js
@@ -76,6 +76,16 @@ describe('Resource', () => {
         expect(e).to.be.instanceOf(ChartMogul.ConfigurationError);
       });
   });
+
+  it('should strip undefined values from POST request body', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .post('/', body => { requestBody = body; return true; })
+      .reply(200, {});
+
+    await Resource.request(config, 'POST', '/', { email: 'x', external_id: undefined });
+    expect(requestBody).to.not.have.property('external_id');
+  });
 });
 
 describe('Resource Retry', () => {


### PR DESCRIPTION
This PR updates the Contact model tests to demonstrate how the `external_id` field can be set in both CREATE and UPDATE requests. The `external_id` field can be either a string or null.