### PR TITLE
Add SubscriptionEvent wrapping/disable/enable and Invoice updateStatus/disable

### DIFF
--- a/lib/chartmogul.js
+++ b/lib/chartmogul.js
@@ -14,6 +14,7 @@ const Ping = require('./chartmogul/ping');
 const Task = require('./chartmogul/task');
 
 const Invoice = require('./chartmogul/invoice');
+const LineItem = require('./chartmogul/line-item');
 const Subscription = require('./chartmogul/subscription');
 const Transaction = require('./chartmogul/transaction');
 const SubscriptionEvent = require('./chartmogul/subscription_event');
@@ -39,6 +40,7 @@ const ChartMogul = {
   Enrichment,
   Import,
   Invoice,
+  LineItem,
   Metrics,
   Opportunity,
   Ping,

--- a/lib/chartmogul/account.js
+++ b/lib/chartmogul/account.js
@@ -2,10 +2,38 @@
 
 const Resource = require('./resource.js');
 
+const VALID_INCLUDE_FIELDS = [
+  'churn_recognition',
+  'churn_when_zero_mrr',
+  'auto_churn_subscription',
+  'refund_handling',
+  'proximate_movement_reclassification'
+];
+
 class Account extends Resource {
   static get path () {
     return '/v1/account';
   }
 }
+
+// @Override retrieve to validate include param
+Account._retrieve = Resource._method('GET');
+Account.retrieve = function (config, params, callback) {
+  if (params && params.include) {
+    const fields = params.include.split(',').map(function (f) { return f.trim(); });
+    const invalid = fields.filter(function (f) { return VALID_INCLUDE_FIELDS.indexOf(f) === -1; });
+    if (invalid.length > 0) {
+      console.warn(
+        '[chartmogul] Account.retrieve: unknown include field(s): ' +
+        invalid.join(', ') +
+        '. Allowed: ' + VALID_INCLUDE_FIELDS.join(', ')
+      );
+    }
+  }
+  const args = [config];
+  if (params) args.push(params);
+  if (typeof callback === 'function') args.push(callback);
+  return Account._retrieve.apply(this, args);
+};
 
 module.exports = Account;

--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -27,10 +27,32 @@ Invoice.destroy_all = Resource._method('DELETE', 'v1/data_sources{/data_source_u
 
 Invoice.retrieve = Resource._method('GET', '/v1/invoices{/uuid}');
 
-// PATCH to the same /v1/invoices/:uuid endpoint — the API uses the request
-// body (e.g. { status: 'void' }) to distinguish a status update from other patches.
-Invoice.updateStatus = Resource._method('PATCH', '/v1/invoices{/uuid}');
+// PUT /v1/data_sources/:ds_uuid/invoices/:invoice_external_id/status
+// Body: { status: 'voided' | 'written_off' }
+Invoice.updateStatus = Resource._method('PUT', '/v1/data_sources{/data_source_uuid}/invoices{/invoice_external_id}/status');
 
-Invoice.disable = Resource._method('PATCH', '/v1/invoices{/uuid}/disable');
+// Disable/enable via PATCH /v1/invoices/:uuid/disabled_state
+// Convenience wrapper: automatically sends { disabled: true }.
+Invoice._setDisabledState = Resource._method('PATCH', '/v1/invoices{/uuid}/disabled_state');
+Invoice.disable = function (config, uuid, dataOrCb, callback) {
+  // Support: disable(config, uuid), disable(config, uuid, cb), disable(config, uuid, body, cb)
+  let body = { disabled: true };
+  let cb;
+  if (typeof dataOrCb === 'function') {
+    cb = dataOrCb;
+  } else if (dataOrCb && typeof dataOrCb === 'object') {
+    body = Object.assign({}, dataOrCb, { disabled: true });
+    cb = callback;
+  }
+  const args = [config, uuid, body];
+  if (typeof cb === 'function') args.push(cb);
+  return Invoice._setDisabledState.apply(this, args);
+};
+
+Invoice.enable = function (config, uuid, callback) {
+  const args = [config, uuid, { disabled: false }];
+  if (typeof callback === 'function') args.push(callback);
+  return Invoice._setDisabledState.apply(this, args);
+};
 
 module.exports = Invoice;

--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -55,4 +55,25 @@ Invoice.enable = function (config, uuid, callback) {
   return Invoice._setDisabledState.apply(this, args);
 };
 
+// PATCH /v1/invoices?data_source_uuid=X&external_id=Y  { body }
+Invoice.update = Resource._method('PATCH', '/v1/invoices');
+
+// DELETE /v1/invoices?data_source_uuid=X&external_id=Y
+Invoice.destroyByExternalId = Resource._method('DELETE', '/v1/invoices');
+
+// PATCH /v1/invoices/disabled_state?data_source_uuid=X&external_id=Y  { disabled: bool }
+Invoice._setDisabledStateByExternalId = Resource._method('PATCH', '/v1/invoices/disabled_state');
+Invoice.disableByExternalId = function (config, params, callback) {
+  const data = { qs: params, disabled: true };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return Invoice._setDisabledStateByExternalId.apply(this, args);
+};
+Invoice.enableByExternalId = function (config, params, callback) {
+  const data = { qs: params, disabled: false };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return Invoice._setDisabledStateByExternalId.apply(this, args);
+};
+
 module.exports = Invoice;

--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -27,6 +27,8 @@ Invoice.destroy_all = Resource._method('DELETE', 'v1/data_sources{/data_source_u
 
 Invoice.retrieve = Resource._method('GET', '/v1/invoices{/uuid}');
 
+// PATCH to the same /v1/invoices/:uuid endpoint — the API uses the request
+// body (e.g. { status: 'void' }) to distinguish a status update from other patches.
 Invoice.updateStatus = Resource._method('PATCH', '/v1/invoices{/uuid}');
 
 Invoice.disable = Resource._method('PATCH', '/v1/invoices{/uuid}/disable');

--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -27,4 +27,8 @@ Invoice.destroy_all = Resource._method('DELETE', 'v1/data_sources{/data_source_u
 
 Invoice.retrieve = Resource._method('GET', '/v1/invoices{/uuid}');
 
+Invoice.updateStatus = Resource._method('PATCH', '/v1/invoices{/uuid}');
+
+Invoice.disable = Resource._method('PATCH', '/v1/invoices{/uuid}/disable');
+
 module.exports = Invoice;

--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -41,7 +41,7 @@ Invoice.disable = function (config, uuid, dataOrCb, callback) {
   if (typeof dataOrCb === 'function') {
     cb = dataOrCb;
   } else if (dataOrCb && typeof dataOrCb === 'object') {
-    body = Object.assign({}, dataOrCb, { disabled: true });
+    body = { ...dataOrCb, disabled: true };
     cb = callback;
   }
   const args = [config, uuid, body];

--- a/lib/chartmogul/line-item.js
+++ b/lib/chartmogul/line-item.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const Resource = require('./resource.js');
+
+class LineItem extends Resource {
+  static get path () {
+    return '/v1/line_items';
+  }
+}
+
+// GET /v1/line_items?data_source_uuid=X&external_id=Y
+LineItem.all = Resource._method('GET', '/v1/line_items');
+
+// PATCH /v1/line_items?data_source_uuid=X&external_id=Y  { body }
+LineItem.update = Resource._method('PATCH', '/v1/line_items');
+
+// DELETE /v1/line_items?data_source_uuid=X&external_id=Y
+LineItem.destroy = Resource._method('DELETE', '/v1/line_items');
+
+// PATCH /v1/line_items/disabled_state?data_source_uuid=X&external_id=Y  { disabled: bool }
+LineItem._setDisabledState = Resource._method('PATCH', '/v1/line_items/disabled_state');
+LineItem.disable = function (config, params, callback) {
+  const data = { qs: params, disabled: true };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return LineItem._setDisabledState.apply(this, args);
+};
+LineItem.enable = function (config, params, callback) {
+  const data = { qs: params, disabled: false };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return LineItem._setDisabledState.apply(this, args);
+};
+
+module.exports = LineItem;

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -59,8 +59,23 @@ class Resource {
         return reject(error);
       }
 
-      const qs = method === 'GET' ? data : {};
-      const body = method === 'GET' ? {} : stripUndefined(data);
+      // For GET requests, all data becomes query string.
+      // For non-GET requests, data becomes the body — unless data contains
+      // a `qs` key, in which case data.qs becomes the query string and
+      // the remaining keys become the body.  This allows endpoints like
+      // PATCH /v1/invoices?data_source_uuid=X&external_id=Y  { body }
+      let qs, body;
+      if (method === 'GET') {
+        qs = data || {};
+        body = {};
+      } else if (data && data.qs) {
+        qs = data.qs;
+        const { qs: _, ...rest } = data;
+        body = stripUndefined(rest);
+      } else {
+        qs = {};
+        body = stripUndefined(data);
+      }
 
       const options = {
         qs,

--- a/lib/chartmogul/resource.js
+++ b/lib/chartmogul/resource.js
@@ -146,7 +146,9 @@ class Resource {
   static _method (verb, pathOverride) {
     return function (config) {
       // node v4.x doesn't support rest param
-      const args = Array.from(arguments).splice(1);
+      // Filter trailing undefined args so that an explicit undefined callback
+      // doesn't get popped as cb and swallow the data argument.
+      const args = Array.from(arguments).splice(1).filter(function (a) { return a !== undefined; });
       let cb, data;
       if (typeof args[args.length - 1] === 'function') {
         cb = args.pop();

--- a/lib/chartmogul/subscription_event.js
+++ b/lib/chartmogul/subscription_event.js
@@ -3,7 +3,8 @@
 const Resource = require('./resource.js');
 
 function wrapParams (data) {
-  if (data && !data.subscription_event) {
+  if (data && typeof data === 'object' &&
+      !Object.prototype.hasOwnProperty.call(data, 'subscription_event')) {
     return { subscription_event: data };
   }
   return data;
@@ -19,7 +20,7 @@ class SubscriptionEvent extends Resource {
 SubscriptionEvent._create = Resource._method('POST');
 SubscriptionEvent.create = function (config, data, callback) {
   const args = [config, wrapParams(data)];
-  if (callback) args.push(callback);
+  if (typeof callback === 'function') args.push(callback);
   return SubscriptionEvent._create.apply(this, args);
 };
 
@@ -27,7 +28,7 @@ SubscriptionEvent.create = function (config, data, callback) {
 SubscriptionEvent._updateWithParams = Resource._method('PATCH', '/v1/subscription_events');
 SubscriptionEvent.updateWithParams = function (config, data, callback) {
   const args = [config, wrapParams(data)];
-  if (callback) args.push(callback);
+  if (typeof callback === 'function') args.push(callback);
   return SubscriptionEvent._updateWithParams.apply(this, args);
 };
 
@@ -35,7 +36,7 @@ SubscriptionEvent.updateWithParams = function (config, data, callback) {
 SubscriptionEvent._deleteWithParams = Resource._method('DELETE', '/v1/subscription_events');
 SubscriptionEvent.deleteWithParams = function (config, data, callback) {
   const args = [config, wrapParams(data)];
-  if (callback) args.push(callback);
+  if (typeof callback === 'function') args.push(callback);
   return SubscriptionEvent._deleteWithParams.apply(this, args);
 };
 

--- a/lib/chartmogul/subscription_event.js
+++ b/lib/chartmogul/subscription_event.js
@@ -2,13 +2,45 @@
 
 const Resource = require('./resource.js');
 
+function wrapParams (data) {
+  if (data && !data.subscription_event) {
+    return { subscription_event: data };
+  }
+  return data;
+}
+
 class SubscriptionEvent extends Resource {
   static get path () {
     return '/v1/subscription_events';
   }
 }
 
-SubscriptionEvent.updateWithParams = Resource._method('PATCH', this.path);
-SubscriptionEvent.deleteWithParams = Resource._method('DELETE', this.path);
+// @Override create to wrap flat params in envelope
+SubscriptionEvent._create = Resource._method('POST');
+SubscriptionEvent.create = function (config, data, callback) {
+  const args = [config, wrapParams(data)];
+  if (callback) args.push(callback);
+  return SubscriptionEvent._create.apply(this, args);
+};
+
+// @Override update to wrap flat params in envelope
+SubscriptionEvent._updateWithParams = Resource._method('PATCH', '/v1/subscription_events');
+SubscriptionEvent.updateWithParams = function (config, data, callback) {
+  const args = [config, wrapParams(data)];
+  if (callback) args.push(callback);
+  return SubscriptionEvent._updateWithParams.apply(this, args);
+};
+
+// @Override delete to wrap flat params in envelope
+SubscriptionEvent._deleteWithParams = Resource._method('DELETE', '/v1/subscription_events');
+SubscriptionEvent.deleteWithParams = function (config, data, callback) {
+  const args = [config, wrapParams(data)];
+  if (callback) args.push(callback);
+  return SubscriptionEvent._deleteWithParams.apply(this, args);
+};
+
+// Disable/enable state toggling
+SubscriptionEvent.disable = Resource._method('PATCH', '/v1/subscription_events{/id}/disable');
+SubscriptionEvent.enable = Resource._method('PATCH', '/v1/subscription_events{/id}/enable');
 
 module.exports = SubscriptionEvent;

--- a/lib/chartmogul/subscription_event.js
+++ b/lib/chartmogul/subscription_event.js
@@ -28,8 +28,18 @@ wrapMethod('create', 'POST');
 wrapMethod('updateWithParams', 'PATCH', '/v1/subscription_events');
 wrapMethod('deleteWithParams', 'DELETE', '/v1/subscription_events');
 
-// Disable/enable state toggling
-SubscriptionEvent.disable = Resource._method('PATCH', '/v1/subscription_events{/id}/disable');
-SubscriptionEvent.enable = Resource._method('PATCH', '/v1/subscription_events{/id}/enable');
+// Disable/enable state toggling via PATCH /v1/subscription_events/:id/disabled_state
+// These convenience wrappers automatically set { disabled: true/false }.
+SubscriptionEvent._setDisabledState = Resource._method('PATCH', '/v1/subscription_events{/id}/disabled_state');
+SubscriptionEvent.disable = function (config, id, callback) {
+  const args = [config, id, { disabled: true }];
+  if (typeof callback === 'function') args.push(callback);
+  return SubscriptionEvent._setDisabledState.apply(this, args);
+};
+SubscriptionEvent.enable = function (config, id, callback) {
+  const args = [config, id, { disabled: false }];
+  if (typeof callback === 'function') args.push(callback);
+  return SubscriptionEvent._setDisabledState.apply(this, args);
+};
 
 module.exports = SubscriptionEvent;

--- a/lib/chartmogul/subscription_event.js
+++ b/lib/chartmogul/subscription_event.js
@@ -3,11 +3,19 @@
 const Resource = require('./resource.js');
 
 function wrapParams (data) {
-  if (data && typeof data === 'object' &&
-      !Object.prototype.hasOwnProperty.call(data, 'subscription_event')) {
+  if (data && typeof data === 'object' && !data.subscription_event) {
     return { subscription_event: data };
   }
   return data;
+}
+
+function wrapMethod (name, verb, path) {
+  const inner = Resource._method(verb, path);
+  SubscriptionEvent[name] = function (config, data, callback) {
+    const args = [config, wrapParams(data)];
+    if (typeof callback === 'function') args.push(callback);
+    return inner.apply(this, args);
+  };
 }
 
 class SubscriptionEvent extends Resource {
@@ -16,29 +24,9 @@ class SubscriptionEvent extends Resource {
   }
 }
 
-// @Override create to wrap flat params in envelope
-SubscriptionEvent._create = Resource._method('POST');
-SubscriptionEvent.create = function (config, data, callback) {
-  const args = [config, wrapParams(data)];
-  if (typeof callback === 'function') args.push(callback);
-  return SubscriptionEvent._create.apply(this, args);
-};
-
-// @Override update to wrap flat params in envelope
-SubscriptionEvent._updateWithParams = Resource._method('PATCH', '/v1/subscription_events');
-SubscriptionEvent.updateWithParams = function (config, data, callback) {
-  const args = [config, wrapParams(data)];
-  if (typeof callback === 'function') args.push(callback);
-  return SubscriptionEvent._updateWithParams.apply(this, args);
-};
-
-// @Override delete to wrap flat params in envelope
-SubscriptionEvent._deleteWithParams = Resource._method('DELETE', '/v1/subscription_events');
-SubscriptionEvent.deleteWithParams = function (config, data, callback) {
-  const args = [config, wrapParams(data)];
-  if (typeof callback === 'function') args.push(callback);
-  return SubscriptionEvent._deleteWithParams.apply(this, args);
-};
+wrapMethod('create', 'POST');
+wrapMethod('updateWithParams', 'PATCH', '/v1/subscription_events');
+wrapMethod('deleteWithParams', 'DELETE', '/v1/subscription_events');
 
 // Disable/enable state toggling
 SubscriptionEvent.disable = Resource._method('PATCH', '/v1/subscription_events{/id}/disable');

--- a/lib/chartmogul/transaction.js
+++ b/lib/chartmogul/transaction.js
@@ -8,4 +8,28 @@ class Transaction extends Resource {
   }
 }
 
+// GET /v1/transactions?data_source_uuid=X&external_id=Y
+Transaction.all = Resource._method('GET', '/v1/transactions');
+
+// PATCH /v1/transactions?data_source_uuid=X&external_id=Y  { body }
+Transaction.update = Resource._method('PATCH', '/v1/transactions');
+
+// DELETE /v1/transactions?data_source_uuid=X&external_id=Y
+Transaction.destroy = Resource._method('DELETE', '/v1/transactions');
+
+// PATCH /v1/transactions/disabled_state?data_source_uuid=X&external_id=Y  { disabled: bool }
+Transaction._setDisabledState = Resource._method('PATCH', '/v1/transactions/disabled_state');
+Transaction.disable = function (config, params, callback) {
+  const data = { qs: params, disabled: true };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return Transaction._setDisabledState.apply(this, args);
+};
+Transaction.enable = function (config, params, callback) {
+  const data = { qs: params, disabled: false };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return Transaction._setDisabledState.apply(this, args);
+};
+
 module.exports = Transaction;

--- a/test/chartmogul/account.js
+++ b/test/chartmogul/account.js
@@ -63,7 +63,9 @@ describe('Account', () => {
       .reply(400, { message: 'Invalid include parameter: invalid_field' });
 
     return Account.retrieve(config, { include: 'invalid_field' })
+      .then(() => { throw new Error('Expected rejection'); })
       .catch(e => {
+        if (e.message === 'Expected rejection') throw e;
         expect(e.status).to.equal(400);
       });
   });

--- a/test/chartmogul/account.js
+++ b/test/chartmogul/account.js
@@ -12,6 +12,7 @@ describe('Account', () => {
       .get('/v1/account')
       .reply(200, {
         /* eslint-disable camelcase */
+        id: 'acc_a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         name: 'Example Test Company',
         currency: 'EUR',
         time_zone: 'Europe/Berlin',
@@ -20,9 +21,50 @@ describe('Account', () => {
       });
 
     const account = await Account.retrieve(config);
+    expect(account.id).to.be.equal('acc_a1b2c3d4-e5f6-7890-abcd-ef1234567890');
     expect(account.name).to.be.equal('Example Test Company');
     expect(account.currency).to.be.equal('EUR');
     expect(account.time_zone).to.be.equal('Europe/Berlin');
     expect(account.week_start_on).to.be.equal('sunday');
+  });
+
+  it('should retrieve account with include params', async () => {
+    nock(config.API_BASE)
+      .get('/v1/account')
+      .query({
+        /* eslint-disable camelcase */
+        include: 'churn_recognition,churn_when_zero_mrr'
+        /* eslint-enable camelcase */
+      })
+      .reply(200, {
+        /* eslint-disable camelcase */
+        id: 'acc_a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        name: 'Example Test Company',
+        currency: 'EUR',
+        time_zone: 'Europe/Berlin',
+        week_start_on: 'sunday',
+        churn_recognition: 'immediate',
+        churn_when_zero_mrr: true
+        /* eslint-enable camelcase */
+      });
+
+    const account = await Account.retrieve(config, {
+      include: 'churn_recognition,churn_when_zero_mrr'
+    });
+    expect(account.id).to.be.equal('acc_a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+    expect(account.churn_recognition).to.be.equal('immediate');
+    expect(account.churn_when_zero_mrr).to.be.equal(true);
+  });
+
+  it('should reject when retrieving account with invalid include param', () => {
+    nock(config.API_BASE)
+      .get('/v1/account')
+      .query({ include: 'invalid_field' })
+      .reply(400, { message: 'Invalid include parameter: invalid_field' });
+
+    return Account.retrieve(config, { include: 'invalid_field' })
+      .catch(e => {
+        expect(e.status).to.equal(400);
+      });
   });
 });

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -583,3 +583,72 @@ describe('Invoices', () => {
     expect(invoice.has_more).to.eql(false);
   });
 });
+
+/* eslint-disable camelcase */
+const invoiceQueryParams = {
+  data_source_uuid: 'ds_fef05d54-47b4-431b-aed2-eb6b9e545430',
+  external_id: 'INV0001'
+};
+
+const invoiceQueryResponse = {
+  uuid: 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454',
+  external_id: 'INV0001',
+  date: '2026-01-01T00:00:00.000Z',
+  currency: 'USD'
+};
+/* eslint-enable camelcase */
+
+describe('Invoices query params (PIP-306)', () => {
+  it('should update an invoice by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/invoices')
+      .query(invoiceQueryParams)
+      .reply(200, (uri, body) => {
+        requestBody = body;
+        return { ...invoiceQueryResponse, currency: 'EUR' };
+      });
+
+    const res = await Invoice.update(config, {
+      qs: invoiceQueryParams,
+      currency: 'EUR'
+    });
+    expect(res.currency).to.equal('EUR');
+    expect(requestBody).to.have.property('currency', 'EUR');
+    expect(requestBody).to.not.have.property('qs');
+  });
+
+  it('should delete an invoice by query params', async () => {
+    nock(config.API_BASE)
+      .delete('/v1/invoices')
+      .query(invoiceQueryParams)
+      .reply(204, {});
+
+    const res = await Invoice.destroyByExternalId(config, { qs: invoiceQueryParams });
+    expect(res).to.be.an('object');
+  });
+
+  it('should disable an invoice by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/invoices/disabled_state', body => { requestBody = body; return true; })
+      .query(invoiceQueryParams)
+      .reply(200, { ...invoiceQueryResponse, disabled: true });
+
+    const res = await Invoice.disableByExternalId(config, invoiceQueryParams);
+    expect(res.disabled).to.equal(true);
+    expect(requestBody).to.deep.equal({ disabled: true });
+  });
+
+  it('should enable an invoice by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/invoices/disabled_state', body => { requestBody = body; return true; })
+      .query(invoiceQueryParams)
+      .reply(200, { ...invoiceQueryResponse, disabled: false });
+
+    const res = await Invoice.enableByExternalId(config, invoiceQueryParams);
+    expect(res.disabled).to.equal(false);
+    expect(requestBody).to.deep.equal({ disabled: false });
+  });
+});

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -86,7 +86,8 @@ const invoiceListResult = {
         tax_amount_in_cents: 900,
         transaction_fees_currency: 'EUR',
         discount_description: '5 EUR',
-        event_order: 5
+        event_order: 5,
+        error: null
       },
       {
         type: 'one_time',
@@ -97,14 +98,16 @@ const invoiceListResult = {
         discount_amount_in_cents: 500,
         tax_amount_in_cents: 450,
         transaction_fees_currency: 'EUR',
-        discount_description: '2 EUR'
+        discount_description: '2 EUR',
+        error: null
       }
     ],
     transactions: [
       {
         date: '2015-11-05 00:14:23',
         type: 'payment',
-        result: 'successful'
+        result: 'successful',
+        error: null
       }
     ]
   }],
@@ -280,6 +283,132 @@ describe('Invoices', () => {
       });
   });
 
+  it('should update invoice status', () => {
+    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+    /* eslint-disable camelcase */
+    const body = { status: 'void' };
+    const responsePayload = {
+      uuid: invoiceUuid,
+      external_id: 'INV0001',
+      status: 'void'
+    };
+    /* eslint-enable camelcase */
+
+    nock(config.API_BASE)
+      .patch('/v1/invoices/' + invoiceUuid)
+      .reply(200, responsePayload);
+
+    return Invoice.updateStatus(config, invoiceUuid, body)
+      .then(res => {
+        expect(res.uuid).to.equal(invoiceUuid);
+        expect(res.status).to.equal('void');
+      });
+  });
+
+  it('should disable an invoice', () => {
+    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+    /* eslint-disable camelcase */
+    const responsePayload = {
+      uuid: invoiceUuid,
+      external_id: 'INV0001',
+      disabled: true,
+      disabled_at: '2024-01-15T10:30:00.000Z',
+      disabled_by: 'user@example.com'
+    };
+    /* eslint-enable camelcase */
+
+    nock(config.API_BASE)
+      .patch('/v1/invoices/' + invoiceUuid + '/disable')
+      .reply(200, responsePayload);
+
+    return Invoice.disable(config, invoiceUuid)
+      .then(res => {
+        expect(res.uuid).to.equal(invoiceUuid);
+        expect(res.disabled).to.equal(true);
+        expect(res.disabled_at).to.equal('2024-01-15T10:30:00.000Z');
+        expect(res.disabled_by).to.equal('user@example.com');
+      });
+  });
+
+  it('should update invoice status with callback', (done) => {
+    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+
+    nock(config.API_BASE)
+      .patch('/v1/invoices/' + invoiceUuid)
+      .reply(200, { uuid: invoiceUuid, status: 'void' });
+
+    Invoice.updateStatus(config, invoiceUuid, { status: 'void' }, (err, res) => {
+      if (err) return done(err);
+      expect(res.status).to.equal('void');
+      done();
+    });
+  });
+
+  it('should reject when updating invoice with invalid status', () => {
+    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+
+    nock(config.API_BASE)
+      .patch('/v1/invoices/' + invoiceUuid)
+      .reply(422, { message: 'Status transition is not allowed' });
+
+    return Invoice.updateStatus(config, invoiceUuid, { status: 'invalid' })
+      .catch(e => {
+        expect(e.status).to.equal(422);
+      });
+  });
+
+  it('should disable an invoice with callback', (done) => {
+    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+
+    nock(config.API_BASE)
+      .patch('/v1/invoices/' + invoiceUuid + '/disable')
+      .reply(200, {
+        /* eslint-disable camelcase */
+        uuid: invoiceUuid,
+        disabled: true,
+        disabled_at: '2024-01-15T10:30:00.000Z',
+        disabled_by: 'user@example.com'
+        /* eslint-enable camelcase */
+      });
+
+    Invoice.disable(config, invoiceUuid, (err, res) => {
+      if (err) return done(err);
+      expect(res.disabled).to.equal(true);
+      done();
+    });
+  });
+
+  it('should disable an invoice with body params', () => {
+    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+
+    nock(config.API_BASE)
+      .patch('/v1/invoices/' + invoiceUuid + '/disable')
+      .reply(200, {
+        /* eslint-disable camelcase */
+        uuid: invoiceUuid,
+        disabled: true,
+        disabled_at: '2024-01-15T10:30:00.000Z',
+        disabled_by: 'user@example.com'
+        /* eslint-enable camelcase */
+      });
+
+    return Invoice.disable(config, invoiceUuid, { reason: 'duplicate' })
+      .then(res => {
+        expect(res.disabled).to.equal(true);
+      });
+  });
+
+  it('should reject when disabling nonexistent invoice', () => {
+    nock(config.API_BASE)
+      .patch('/v1/invoices/inv_nonexistent/disable')
+      .reply(404, { message: 'Invoice not found' });
+
+    return Invoice.disable(config, 'inv_nonexistent')
+      .catch(e => {
+        expect(e.status).to.equal(404);
+      });
+  });
+
   it('should retrieve an invoice', () => {
     const payload = { external_id: 'some_invoice_id' };
     nock(config.API_BASE)
@@ -371,6 +500,41 @@ describe('Invoices', () => {
         expect(res.errors.date).to.be.an('array');
         expect(res.errors.date).to.have.lengthOf(1);
         expect(res.errors.date[0]).to.equal('Date is in the future');
+      });
+  });
+
+  it('should expose error field on line items and transactions', () => {
+    const invoiceWithErrors = {
+      /* eslint-disable camelcase */
+      external_id: 'INV_ERR',
+      errors: { date: ['Date is invalid'] },
+      line_items: [
+        {
+          type: 'subscription',
+          amount_in_cents: 5000,
+          error: 'Plan not found'
+        }
+      ],
+      transactions: [
+        {
+          date: '2015-11-05 00:14:23',
+          type: 'payment',
+          result: 'failed',
+          error: 'Payment gateway timeout'
+        }
+      ]
+      /* eslint-enable camelcase */
+    };
+
+    nock(config.API_BASE)
+      .get('/v1/invoices/inv_err_001')
+      .reply(200, invoiceWithErrors);
+
+    return Invoice.retrieve(config, 'inv_err_001')
+      .then(res => {
+        expect(res.errors).to.be.an('object');
+        expect(res.line_items[0].error).to.equal('Plan not found');
+        expect(res.transactions[0].error).to.equal('Payment gateway timeout');
       });
   });
 

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -284,28 +284,28 @@ describe('Invoices', () => {
   });
 
   it('should update invoice status', () => {
-    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
     /* eslint-disable camelcase */
-    const body = { status: 'void' };
+    const dsUuid = 'ds_cff3a63c-3915-435e-a675-85a8a8ef4454';
+    const invoiceExtId = 'INV0001';
+    const body = { status: 'voided' };
     const responsePayload = {
-      uuid: invoiceUuid,
-      external_id: 'INV0001',
-      status: 'void'
+      external_id: invoiceExtId,
+      status: 'voided'
     };
     /* eslint-enable camelcase */
 
     nock(config.API_BASE)
-      .patch('/v1/invoices/' + invoiceUuid)
+      .put('/v1/data_sources/' + dsUuid + '/invoices/' + invoiceExtId + '/status')
       .reply(200, responsePayload);
 
-    return Invoice.updateStatus(config, invoiceUuid, body)
+    return Invoice.updateStatus(config, dsUuid, invoiceExtId, body)
       .then(res => {
-        expect(res.uuid).to.equal(invoiceUuid);
-        expect(res.status).to.equal('void');
+        expect(res.external_id).to.equal(invoiceExtId);
+        expect(res.status).to.equal('voided');
       });
   });
 
-  it('should disable an invoice', () => {
+  it('should disable an invoice', async () => {
     const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
     /* eslint-disable camelcase */
     const responsePayload = {
@@ -317,41 +317,43 @@ describe('Invoices', () => {
     };
     /* eslint-enable camelcase */
 
+    let requestBody;
     nock(config.API_BASE)
-      .patch('/v1/invoices/' + invoiceUuid + '/disable')
+      .patch('/v1/invoices/' + invoiceUuid + '/disabled_state', body => { requestBody = body; return true; })
       .reply(200, responsePayload);
 
-    return Invoice.disable(config, invoiceUuid)
-      .then(res => {
-        expect(res.uuid).to.equal(invoiceUuid);
-        expect(res.disabled).to.equal(true);
-        expect(res.disabled_at).to.equal('2024-01-15T10:30:00.000Z');
-        expect(res.disabled_by).to.equal('user@example.com');
-      });
+    const res = await Invoice.disable(config, invoiceUuid);
+    expect(res.uuid).to.equal(invoiceUuid);
+    expect(res.disabled).to.equal(true);
+    expect(res.disabled_at).to.equal('2024-01-15T10:30:00.000Z');
+    expect(res.disabled_by).to.equal('user@example.com');
+    expect(requestBody).to.deep.equal({ disabled: true });
   });
 
   it('should update invoice status with callback', (done) => {
-    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+    const dsUuid = 'ds_cff3a63c-3915-435e-a675-85a8a8ef4454';
+    const invoiceExtId = 'INV0001';
 
     nock(config.API_BASE)
-      .patch('/v1/invoices/' + invoiceUuid)
-      .reply(200, { uuid: invoiceUuid, status: 'void' });
+      .put('/v1/data_sources/' + dsUuid + '/invoices/' + invoiceExtId + '/status')
+      .reply(200, { external_id: invoiceExtId, status: 'voided' });
 
-    Invoice.updateStatus(config, invoiceUuid, { status: 'void' }, (err, res) => {
+    Invoice.updateStatus(config, dsUuid, invoiceExtId, { status: 'voided' }, (err, res) => {
       if (err) return done(err);
-      expect(res.status).to.equal('void');
+      expect(res.status).to.equal('voided');
       done();
     });
   });
 
   it('should reject when updating invoice with invalid status', () => {
-    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+    const dsUuid = 'ds_cff3a63c-3915-435e-a675-85a8a8ef4454';
+    const invoiceExtId = 'INV0001';
 
     nock(config.API_BASE)
-      .patch('/v1/invoices/' + invoiceUuid)
+      .put('/v1/data_sources/' + dsUuid + '/invoices/' + invoiceExtId + '/status')
       .reply(422, { message: 'Status transition is not allowed' });
 
-    return Invoice.updateStatus(config, invoiceUuid, { status: 'invalid' })
+    return Invoice.updateStatus(config, dsUuid, invoiceExtId, { status: 'invalid' })
       .then(() => { throw new Error('Expected rejection'); })
       .catch(e => {
         if (e.message === 'Expected rejection') throw e;
@@ -363,7 +365,7 @@ describe('Invoices', () => {
     const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
 
     nock(config.API_BASE)
-      .patch('/v1/invoices/' + invoiceUuid + '/disable')
+      .patch('/v1/invoices/' + invoiceUuid + '/disabled_state')
       .reply(200, {
         /* eslint-disable camelcase */
         uuid: invoiceUuid,
@@ -385,7 +387,7 @@ describe('Invoices', () => {
 
     let requestBody;
     nock(config.API_BASE)
-      .patch('/v1/invoices/' + invoiceUuid + '/disable', body => { requestBody = body; return true; })
+      .patch('/v1/invoices/' + invoiceUuid + '/disabled_state', body => { requestBody = body; return true; })
       .reply(200, {
         /* eslint-disable camelcase */
         uuid: invoiceUuid,
@@ -399,12 +401,13 @@ describe('Invoices', () => {
       .then(res => {
         expect(res.disabled).to.equal(true);
         expect(requestBody).to.have.property('reason', 'duplicate');
+        expect(requestBody).to.have.property('disabled', true);
       });
   });
 
   it('should reject when disabling nonexistent invoice', () => {
     nock(config.API_BASE)
-      .patch('/v1/invoices/inv_nonexistent/disable')
+      .patch('/v1/invoices/inv_nonexistent/disabled_state')
       .reply(404, { message: 'Invoice not found' });
 
     return Invoice.disable(config, 'inv_nonexistent')

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -352,7 +352,9 @@ describe('Invoices', () => {
       .reply(422, { message: 'Status transition is not allowed' });
 
     return Invoice.updateStatus(config, invoiceUuid, { status: 'invalid' })
+      .then(() => { throw new Error('Expected rejection'); })
       .catch(e => {
+        if (e.message === 'Expected rejection') throw e;
         expect(e.status).to.equal(422);
       });
   });
@@ -381,8 +383,9 @@ describe('Invoices', () => {
   it('should disable an invoice with body params', () => {
     const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
 
+    let requestBody;
     nock(config.API_BASE)
-      .patch('/v1/invoices/' + invoiceUuid + '/disable')
+      .patch('/v1/invoices/' + invoiceUuid + '/disable', body => { requestBody = body; return true; })
       .reply(200, {
         /* eslint-disable camelcase */
         uuid: invoiceUuid,
@@ -395,6 +398,7 @@ describe('Invoices', () => {
     return Invoice.disable(config, invoiceUuid, { reason: 'duplicate' })
       .then(res => {
         expect(res.disabled).to.equal(true);
+        expect(requestBody).to.have.property('reason', 'duplicate');
       });
   });
 
@@ -404,7 +408,9 @@ describe('Invoices', () => {
       .reply(404, { message: 'Invoice not found' });
 
     return Invoice.disable(config, 'inv_nonexistent')
+      .then(() => { throw new Error('Expected rejection'); })
       .catch(e => {
+        if (e.message === 'Expected rejection') throw e;
         expect(e.status).to.equal(404);
       });
   });

--- a/test/chartmogul/line-item.js
+++ b/test/chartmogul/line-item.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const ChartMogul = require('../../lib/chartmogul');
+const config = new ChartMogul.Config('token');
+const expect = require('chai').expect;
+const nock = require('nock');
+const LineItem = ChartMogul.LineItem;
+
+/* eslint-disable camelcase */
+const queryParams = {
+  data_source_uuid: 'ds_fef05d54-47b4-431b-aed2-eb6b9e545430',
+  external_id: 'li_ext_001'
+};
+
+const lineItemResponse = {
+  uuid: 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b',
+  external_id: 'li_ext_001',
+  type: 'subscription',
+  amount_in_cents: 10000,
+  quantity: 1
+};
+/* eslint-enable camelcase */
+
+describe('LineItem', () => {
+  it('should get line items by data_source_uuid and external_id', () => {
+    nock(config.API_BASE)
+      .get('/v1/line_items')
+      .query(queryParams)
+      .reply(200, { line_items: [lineItemResponse] });
+
+    return LineItem.all(config, queryParams)
+      .then(res => {
+        expect(res.line_items).to.be.an('array');
+        expect(res.line_items[0].external_id).to.equal('li_ext_001');
+      });
+  });
+
+  it('should update a line item by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/line_items')
+      .query(queryParams)
+      .reply(200, (uri, body) => {
+        requestBody = body;
+        return { ...lineItemResponse, amount_in_cents: 20000 };
+      });
+
+    const res = await LineItem.update(config, {
+      qs: queryParams,
+      amount_in_cents: 20000
+    });
+    expect(res.amount_in_cents).to.equal(20000);
+    expect(requestBody).to.have.property('amount_in_cents', 20000);
+    expect(requestBody).to.not.have.property('qs');
+  });
+
+  it('should delete a line item by query params', async () => {
+    nock(config.API_BASE)
+      .delete('/v1/line_items')
+      .query(queryParams)
+      .reply(204, {});
+
+    const res = await LineItem.destroy(config, { qs: queryParams });
+    expect(res).to.be.an('object');
+  });
+
+  it('should disable a line item by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/line_items/disabled_state', body => { requestBody = body; return true; })
+      .query(queryParams)
+      .reply(200, { ...lineItemResponse, disabled: true });
+
+    const res = await LineItem.disable(config, queryParams);
+    expect(res.disabled).to.equal(true);
+    expect(requestBody).to.deep.equal({ disabled: true });
+  });
+
+  it('should enable a line item by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/line_items/disabled_state', body => { requestBody = body; return true; })
+      .query(queryParams)
+      .reply(200, { ...lineItemResponse, disabled: false });
+
+    const res = await LineItem.enable(config, queryParams);
+    expect(res.disabled).to.equal(false);
+    expect(requestBody).to.deep.equal({ disabled: false });
+  });
+});

--- a/test/chartmogul/subscription-event.js
+++ b/test/chartmogul/subscription-event.js
@@ -18,7 +18,9 @@ describe('SubscriptionEvent', () => {
       .query(query)
       .reply(200, {});
     return SubscriptionEvent.all(config, query)
+      .then(() => { throw new Error('Expected rejection'); })
       .catch(e => {
+        if (e.message === 'Expected rejection') throw e;
         expect(e.httpStatus).to.equal(422);
         expect(e.message).to.equal('"page" param is deprecated {}');
       });
@@ -202,6 +204,27 @@ describe('SubscriptionEvent', () => {
     expect(requestBody.subscription_event.external_id).to.eq('ex_id_1');
   });
 
+  it('should create a subscription event with callback', (done) => {
+    nock(config.API_BASE)
+      .post(path, body => body.subscription_event)
+      .reply(201, {
+        subscription_event: { id: 102, external_id: 'ex_cb_1' }
+      });
+
+    SubscriptionEvent.create(config, {
+      customer_external_id: 'c_ex_id_1',
+      data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
+      event_type: 'subscription_cancelled',
+      external_id: 'ex_cb_1',
+      subscription_external_id: 'sub_ex_id_1'
+    }, (err, res) => {
+      if (err) return done(err);
+      expect(res).to.have.property('subscription_event');
+      expect(res.subscription_event.external_id).to.eq('ex_cb_1');
+      done();
+    });
+  });
+
   it('should disable a subscription event', () => {
     nock(config.API_BASE)
       .patch('/v1/subscription_events/101/disable')
@@ -238,7 +261,9 @@ describe('SubscriptionEvent', () => {
       .reply(404, { message: 'Subscription event not found' });
 
     return SubscriptionEvent.disable(config, 999)
+      .then(() => { throw new Error('Expected rejection'); })
       .catch(e => {
+        if (e.message === 'Expected rejection') throw e;
         expect(e.status).to.equal(404);
       });
   });
@@ -249,7 +274,9 @@ describe('SubscriptionEvent', () => {
       .reply(404, { message: 'Subscription event not found' });
 
     return SubscriptionEvent.enable(config, 999)
+      .then(() => { throw new Error('Expected rejection'); })
       .catch(e => {
+        if (e.message === 'Expected rejection') throw e;
         expect(e.status).to.equal(404);
       });
   });

--- a/test/chartmogul/subscription-event.js
+++ b/test/chartmogul/subscription-event.js
@@ -64,163 +64,193 @@ describe('SubscriptionEvent', () => {
     });
   });
 
-  it('should create a subscription event', () => {
-    const postBody = {
+  it('should create a subscription event with flat params and wrap in envelope', async () => {
+    const flatParams = {
+      customer_external_id: 'c_ex_id_1',
+      data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
+      effective_date: '2022-06-13T12:30:35.160Z',
+      event_date: '2022-06-12T10:30:35.160Z',
+      event_type: 'subscription_cancelled',
+      external_id: 'ex_id_1',
+      subscription_external_id: 'sub_ex_id_1'
+    };
+
+    let requestBody;
+    nock(config.API_BASE)
+      .post(path, body => { requestBody = body; return true; })
+      .reply(201, {
+        subscription_event: {
+          id: 101,
+          external_id: 'ex_id_1'
+        }
+      });
+
+    const res = await SubscriptionEvent.create(config, flatParams);
+    expect(res).to.have.property('subscription_event');
+    expect(requestBody).to.have.property('subscription_event');
+    expect(requestBody.subscription_event.customer_external_id).to.eq('c_ex_id_1');
+  });
+
+  it('should create a subscription event with envelope params (backward compat)', async () => {
+    const envelopeParams = {
       subscription_event: {
         customer_external_id: 'c_ex_id_1',
         data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
-        effective_date: '2022-06-13T12:30:35.160Z',
-        event_date: '2022-06-12T10:30:35.160Z',
         event_type: 'subscription_cancelled',
         external_id: 'ex_id_1',
         subscription_external_id: 'sub_ex_id_1'
       }
     };
 
+    let requestBody;
     nock(config.API_BASE)
-      .post(path)
+      .post(path, body => { requestBody = body; return true; })
       .reply(201, {
         subscription_event: {
           id: 101,
-          data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
-          customer_external_id: 'c_ex_id_1',
-          subscription_set_external_id: null,
-          subscription_external_id: 'sub_ex_id_1',
-          plan_external_id: null,
-          event_date: '2022-06-12T10:30:35.160Z',
-          effective_date: '2022-06-13T12:30:35.160Z',
-          event_type: 'subscription_cancelled',
-          external_id: 'ex_id_1',
-          errors: {},
-          created_at: '2022-06-13T11:06:56Z',
-          updated_at: '2022-06-13T12:19:40Z',
-          quantity: null,
-          currency: null,
-          amount_in_cents: null,
-          tax_amount_in_cents: null,
-          retracted_event_id: null
+          external_id: 'ex_id_1'
         }
       });
 
-    return SubscriptionEvent.create(config, postBody)
-      .then(res => {
-        expect(res).to.have.property('subscription_event');
-      });
+    const res = await SubscriptionEvent.create(config, envelopeParams);
+    expect(res).to.have.property('subscription_event');
+    expect(requestBody).to.have.property('subscription_event');
+    expect(requestBody.subscription_event.customer_external_id).to.eq('c_ex_id_1');
+    // Should NOT double-wrap
+    expect(requestBody.subscription_event).to.not.have.property('subscription_event');
   });
 
-  it('should update a subscription event using id', () => {
-    const updateBody = {
-      subscription_event: {
-        id: 101,
-        plan_external_id: 'gazillion_monthly_gold'
-      }
+  it('should update a subscription event wrapping flat params with id', async () => {
+    const flatParams = {
+      id: 101,
+      plan_external_id: 'gazillion_monthly_gold'
     };
 
+    let requestBody;
     nock(config.API_BASE)
-      .patch(path)
+      .patch(path, body => { requestBody = body; return true; })
       .reply(200, {
         subscription_event: {
           id: 101,
-          data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
-          customer_external_id: 'c_ex_id_1',
-          subscription_set_external_id: null,
-          subscription_external_id: 'sub_ex_id_1',
-          plan_external_id: 'gazillion_monthly_gold',
-          event_date: '2022-06-12T10:30:35.160Z',
-          effective_date: '2022-06-13T12:30:35.160Z',
-          event_type: 'subscription_cancelled',
-          external_id: 'ex_id_1',
-          errors: {},
-          created_at: '2022-06-13T11:06:56Z',
-          updated_at: '2022-06-13T12:19:40Z',
-          quantity: null,
-          currency: null,
-          amount_in_cents: null,
-          tax_amount_in_cents: null,
-          retracted_event_id: null
+          plan_external_id: 'gazillion_monthly_gold'
         }
       });
 
-    return SubscriptionEvent.updateWithParams(config, updateBody).then(res => {
-      expect(res).to.have.property('subscription_event');
-      expect(res.subscription_event.plan_external_id).to.eq('gazillion_monthly_gold');
-    });
+    const res = await SubscriptionEvent.updateWithParams(config, flatParams);
+    expect(res.subscription_event.plan_external_id).to.eq('gazillion_monthly_gold');
+    expect(requestBody).to.have.property('subscription_event');
+    expect(requestBody.subscription_event.id).to.eq(101);
   });
 
-  it('should update a subscription event using external_id and data_source_uuid', () => {
-    const updateBody = {
-      subscription_event: {
-        external_id: 'ex_id_1',
-        data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
-        plan_external_id: 'gazillion_monthly_gold'
-      }
+  it('should update a subscription event wrapping flat params with external_id', async () => {
+    const flatParams = {
+      external_id: 'ex_id_1',
+      data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
+      plan_external_id: 'gazillion_monthly_gold'
     };
 
+    let requestBody;
     nock(config.API_BASE)
-      .patch(path)
+      .patch(path, body => { requestBody = body; return true; })
       .reply(200, {
         subscription_event: {
           id: 101,
-          data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1',
-          customer_external_id: 'c_ex_id_1',
-          subscription_set_external_id: null,
-          subscription_external_id: 'sub_ex_id_1',
-          plan_external_id: 'gazillion_monthly_gold',
-          event_date: '2022-06-12T10:30:35.160Z',
-          effective_date: '2022-06-13T12:30:35.160Z',
-          event_type: 'subscription_cancelled',
-          external_id: 'ex_id_1',
-          errors: {},
-          created_at: '2022-06-13T11:06:56Z',
-          updated_at: '2022-06-13T12:19:40Z',
-          quantity: null,
-          currency: null,
-          amount_in_cents: null,
-          tax_amount_in_cents: null,
-          retracted_event_id: null
+          plan_external_id: 'gazillion_monthly_gold'
         }
       });
 
-    return SubscriptionEvent.updateWithParams(config, updateBody).then(res => {
-      expect(res).to.have.property('subscription_event');
-      expect(res.subscription_event.plan_external_id).to.eq('gazillion_monthly_gold');
+    const res = await SubscriptionEvent.updateWithParams(config, flatParams);
+    expect(res.subscription_event.plan_external_id).to.eq('gazillion_monthly_gold');
+    expect(requestBody).to.have.property('subscription_event');
+    expect(requestBody.subscription_event.external_id).to.eq('ex_id_1');
+  });
+
+  it('should delete a subscription event wrapping flat params with id', async () => {
+    const flatParams = {
+      id: 101
+    };
+
+    let requestBody;
+    nock(config.API_BASE)
+      .delete(path, body => { requestBody = body; return true; })
+      .reply(204, {});
+
+    const res = await SubscriptionEvent.deleteWithParams(config, flatParams);
+    /* eslint-disable no-unused-expressions */
+    expect(res).to.be.an('object').that.is.empty;
+    /* eslint-enable no-unused-expressions */
+    expect(requestBody).to.have.property('subscription_event');
+    expect(requestBody.subscription_event.id).to.eq(101);
+  });
+
+  it('should delete a subscription event wrapping flat params with external_id', async () => {
+    const flatParams = {
+      external_id: 'ex_id_1',
+      data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
+    };
+
+    let requestBody;
+    nock(config.API_BASE)
+      .delete(path, body => { requestBody = body; return true; })
+      .reply(204, {});
+
+    const res = await SubscriptionEvent.deleteWithParams(config, flatParams);
+    /* eslint-disable no-unused-expressions */
+    expect(res).to.be.an('object').that.is.empty;
+    /* eslint-enable no-unused-expressions */
+    expect(requestBody).to.have.property('subscription_event');
+    expect(requestBody.subscription_event.external_id).to.eq('ex_id_1');
+  });
+
+  it('should disable a subscription event', () => {
+    nock(config.API_BASE)
+      .patch('/v1/subscription_events/101/disable')
+      .reply(200, {
+        subscription_event: {
+          id: 101,
+          disabled: true
+        }
+      });
+
+    return SubscriptionEvent.disable(config, 101).then(res => {
+      expect(res.subscription_event.disabled).to.eq(true);
     });
   });
 
-  it('should delete a subscription event using id', () => {
-    const deleteBody = {
-      subscription_event: {
-        id: 101
-      }
-    };
-
+  it('should enable a subscription event', () => {
     nock(config.API_BASE)
-      .delete(path)
-      .reply(204, {});
+      .patch('/v1/subscription_events/101/enable')
+      .reply(200, {
+        subscription_event: {
+          id: 101,
+          disabled: false
+        }
+      });
 
-    return SubscriptionEvent.deleteWithParams(config, deleteBody).then(res => {
-      /* eslint-disable no-unused-expressions */
-      expect(res).to.be.an('object').that.is.empty;
-      /* eslint-enable no-unused-expressions */
+    return SubscriptionEvent.enable(config, 101).then(res => {
+      expect(res.subscription_event.disabled).to.eq(false);
     });
   });
 
-  it('should delete a subscription event using external_id and data_source_uuid', () => {
-    const deleteBody = {
-      subscription_event: {
-        external_id: 'ex_id_1',
-        data_source_uuid: 'ds_e243129a-12c0-4e29-8f54-07da7905fbd1'
-      }
-    };
-
+  it('should reject when disabling nonexistent event', () => {
     nock(config.API_BASE)
-      .delete(path)
-      .reply(204, {});
+      .patch('/v1/subscription_events/999/disable')
+      .reply(404, { message: 'Subscription event not found' });
 
-    return SubscriptionEvent.deleteWithParams(config, deleteBody).then(res => {
-      /* eslint-disable no-unused-expressions */
-      expect(res).to.be.an('object').that.is.empty;
-      /* eslint-enable no-unused-expressions */
-    });
+    return SubscriptionEvent.disable(config, 999)
+      .catch(e => {
+        expect(e.status).to.equal(404);
+      });
+  });
+
+  it('should reject when enabling nonexistent event', () => {
+    nock(config.API_BASE)
+      .patch('/v1/subscription_events/999/enable')
+      .reply(404, { message: 'Subscription event not found' });
+
+    return SubscriptionEvent.enable(config, 999)
+      .catch(e => {
+        expect(e.status).to.equal(404);
+      });
   });
 });

--- a/test/chartmogul/subscription-event.js
+++ b/test/chartmogul/subscription-event.js
@@ -225,9 +225,10 @@ describe('SubscriptionEvent', () => {
     });
   });
 
-  it('should disable a subscription event', () => {
+  it('should disable a subscription event', async () => {
+    let requestBody;
     nock(config.API_BASE)
-      .patch('/v1/subscription_events/101/disable')
+      .patch('/v1/subscription_events/101/disabled_state', body => { requestBody = body; return true; })
       .reply(200, {
         subscription_event: {
           id: 101,
@@ -235,14 +236,15 @@ describe('SubscriptionEvent', () => {
         }
       });
 
-    return SubscriptionEvent.disable(config, 101).then(res => {
-      expect(res.subscription_event.disabled).to.eq(true);
-    });
+    const res = await SubscriptionEvent.disable(config, 101);
+    expect(res.subscription_event.disabled).to.eq(true);
+    expect(requestBody).to.deep.equal({ disabled: true });
   });
 
-  it('should enable a subscription event', () => {
+  it('should enable a subscription event', async () => {
+    let requestBody;
     nock(config.API_BASE)
-      .patch('/v1/subscription_events/101/enable')
+      .patch('/v1/subscription_events/101/disabled_state', body => { requestBody = body; return true; })
       .reply(200, {
         subscription_event: {
           id: 101,
@@ -250,14 +252,14 @@ describe('SubscriptionEvent', () => {
         }
       });
 
-    return SubscriptionEvent.enable(config, 101).then(res => {
-      expect(res.subscription_event.disabled).to.eq(false);
-    });
+    const res = await SubscriptionEvent.enable(config, 101);
+    expect(res.subscription_event.disabled).to.eq(false);
+    expect(requestBody).to.deep.equal({ disabled: false });
   });
 
   it('should reject when disabling nonexistent event', () => {
     nock(config.API_BASE)
-      .patch('/v1/subscription_events/999/disable')
+      .patch('/v1/subscription_events/999/disabled_state')
       .reply(404, { message: 'Subscription event not found' });
 
     return SubscriptionEvent.disable(config, 999)
@@ -270,7 +272,7 @@ describe('SubscriptionEvent', () => {
 
   it('should reject when enabling nonexistent event', () => {
     nock(config.API_BASE)
-      .patch('/v1/subscription_events/999/enable')
+      .patch('/v1/subscription_events/999/disabled_state')
       .reply(404, { message: 'Subscription event not found' });
 
     return SubscriptionEvent.enable(config, 999)

--- a/test/chartmogul/transaction.js
+++ b/test/chartmogul/transaction.js
@@ -36,3 +36,86 @@ describe('Transaction', () => {
       });
   });
 });
+
+/* eslint-disable camelcase */
+const queryParams = {
+  data_source_uuid: 'ds_fef05d54-47b4-431b-aed2-eb6b9e545430',
+  external_id: 'tr_ext_001'
+};
+
+const transactionResponse = {
+  uuid: 'tr_73b392ce-f141-4d14-97f0-6baf93d8bf68',
+  external_id: 'tr_ext_001',
+  type: 'payment',
+  date: '2026-01-24T09:14:29.000Z',
+  result: 'successful'
+};
+/* eslint-enable camelcase */
+
+describe('Transaction query params', () => {
+  it('should get transactions by data_source_uuid and external_id', () => {
+    nock(config.API_BASE)
+      .get('/v1/transactions')
+      .query(queryParams)
+      .reply(200, { transactions: [transactionResponse] });
+
+    return Transaction.all(config, queryParams)
+      .then(res => {
+        expect(res.transactions).to.be.an('array');
+        expect(res.transactions[0].external_id).to.equal('tr_ext_001');
+      });
+  });
+
+  it('should update a transaction by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/transactions')
+      .query(queryParams)
+      .reply(200, (uri, body) => {
+        requestBody = body;
+        return { ...transactionResponse, result: 'failed' };
+      });
+
+    const res = await Transaction.update(config, {
+      qs: queryParams,
+      result: 'failed'
+    });
+    expect(res.result).to.equal('failed');
+    expect(requestBody).to.have.property('result', 'failed');
+    expect(requestBody).to.not.have.property('qs');
+  });
+
+  it('should delete a transaction by query params', async () => {
+    nock(config.API_BASE)
+      .delete('/v1/transactions')
+      .query(queryParams)
+      .reply(204, {});
+
+    const res = await Transaction.destroy(config, { qs: queryParams });
+    expect(res).to.be.an('object');
+  });
+
+  it('should disable a transaction by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/transactions/disabled_state', body => { requestBody = body; return true; })
+      .query(queryParams)
+      .reply(200, { ...transactionResponse, disabled: true });
+
+    const res = await Transaction.disable(config, queryParams);
+    expect(res.disabled).to.equal(true);
+    expect(requestBody).to.deep.equal({ disabled: true });
+  });
+
+  it('should enable a transaction by query params', async () => {
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/transactions/disabled_state', body => { requestBody = body; return true; })
+      .query(queryParams)
+      .reply(200, { ...transactionResponse, disabled: false });
+
+    const res = await Transaction.enable(config, queryParams);
+    expect(res.disabled).to.equal(false);
+    expect(requestBody).to.deep.equal({ disabled: false });
+  });
+});


### PR DESCRIPTION
## Summary

Closes PIP-311

- Add auto-wrapping of flat params into `subscription_event` envelope for create/update/delete, with backward compatibility for already-enveloped inputs
- Add `SubscriptionEvent.disable` / `SubscriptionEvent.enable` via `/disabled_state` endpoint
- Fix bug where passing `undefined` callback to `_method()` blocked request body from being sent
- Add `Invoice.updateStatus` (PUT `/v1/data_sources/:ds/invoices/:ext_id/status`)
- Add `Invoice.disable` / `Invoice.enable` via `/disabled_state` endpoint
- Add `Account.retrieve` include param validation (warns on unknown fields)
- Add query string support for non-GET methods in `Resource.request` (PIP-306)
- Add `LineItem` resource class with GET/PATCH/DELETE + disabled_state endpoints (PIP-306)
- Add `Transaction` query-param endpoints: all/update/destroy/disable/enable (PIP-306)
- Add `Invoice` query-param endpoints: update/destroyByExternalId/disableByExternalId/enableByExternalId (PIP-306)
- Expand test coverage: body-wrapping verification, callback style, error handling, query-param splitting, and Account `include` query param

## Backwards compatibility review

### Additive (zero risk)
| New method | Notes |
|---|---|
| `Invoice.updateStatus(config, dsUuid, extId, body[, cb])` | PUT `/v1/data_sources/:ds/invoices/:ext_id/status` |
| `Invoice.disable(config, uuid[, body][, cb])` | PATCH `/v1/invoices/:uuid/disabled_state` — auto-sends `{disabled: true}` |
| `Invoice.enable(config, uuid[, cb])` | PATCH `/v1/invoices/:uuid/disabled_state` — auto-sends `{disabled: false}` |
| `Invoice.update(config, { qs: {ds_uuid, ext_id}, ...body })` | PATCH `/v1/invoices?data_source_uuid&external_id` |
| `Invoice.destroyByExternalId(config, { qs: {ds_uuid, ext_id} })` | DELETE `/v1/invoices?data_source_uuid&external_id` |
| `Invoice.disableByExternalId(config, {ds_uuid, ext_id})` | PATCH `/v1/invoices/disabled_state?data_source_uuid&external_id` |
| `Invoice.enableByExternalId(config, {ds_uuid, ext_id})` | PATCH `/v1/invoices/disabled_state?data_source_uuid&external_id` |
| `LineItem.all(config, {ds_uuid, ext_id})` | GET `/v1/line_items?data_source_uuid&external_id` |
| `LineItem.update(config, { qs: {ds_uuid, ext_id}, ...body })` | PATCH `/v1/line_items?data_source_uuid&external_id` |
| `LineItem.destroy(config, { qs: {ds_uuid, ext_id} })` | DELETE `/v1/line_items?data_source_uuid&external_id` |
| `LineItem.disable(config, {ds_uuid, ext_id})` | PATCH `/v1/line_items/disabled_state?data_source_uuid&external_id` |
| `LineItem.enable(config, {ds_uuid, ext_id})` | PATCH `/v1/line_items/disabled_state?data_source_uuid&external_id` |
| `Transaction.all(config, {ds_uuid, ext_id})` | GET `/v1/transactions?data_source_uuid&external_id` |
| `Transaction.update(config, { qs: {ds_uuid, ext_id}, ...body })` | PATCH `/v1/transactions?data_source_uuid&external_id` |
| `Transaction.destroy(config, { qs: {ds_uuid, ext_id} })` | DELETE `/v1/transactions?data_source_uuid&external_id` |
| `Transaction.disable(config, {ds_uuid, ext_id})` | PATCH `/v1/transactions/disabled_state?data_source_uuid&external_id` |
| `Transaction.enable(config, {ds_uuid, ext_id})` | PATCH `/v1/transactions/disabled_state?data_source_uuid&external_id` |
| `SubscriptionEvent.disable(config, id[, cb])` | PATCH `/v1/subscription_events/:id/disabled_state` |
| `SubscriptionEvent.enable(config, id[, cb])` | PATCH `/v1/subscription_events/:id/disabled_state` |

### Behaviour changes (safe)
| Change | Detail | Why it's safe |
|---|---|---|
| `SubscriptionEvent.create` now accepts flat params | `wrapParams` auto-wraps `{foo: 1}` to `{subscription_event: {foo: 1}}` | Callers already passing the envelope are detected (`data.subscription_event` truthy) and **not** double-wrapped. Flat-param callers were previously sending the wrong shape to the API — this is a bug fix. |
| `SubscriptionEvent.updateWithParams` / `deleteWithParams` same wrapping | Identical logic to above | Same reasoning — envelope callers unaffected, flat callers get fixed. |
| `Resource._method` filters trailing `undefined` args | `Array.from(arguments).splice(1).filter(a => a !== undefined)` | On main, `fn(config, data, undefined)` would pop `undefined` as `cb`, then pop `data` as the next candidate — silently losing the request body. After the fix, `undefined` is stripped and `data` is correctly identified. No legitimate call path passes `undefined` intentionally. |
| `Resource.request` extracts `qs` from data for non-GET methods | If `data.qs` exists, it becomes the URL query string and the rest becomes body | Existing callers never pass a `qs` key. GET requests are unaffected (all data already becomes query string). |
| `Account.retrieve` validates `include` param | Warns (does not throw) if unknown field names are passed | Purely additive console warning; no behaviour change for valid inputs |

### Not changed
- `SubscriptionEvent.all` — untouched
- `Invoice.create` / `Invoice.all` / `Invoice.retrieve` / `Invoice.destroy` / `Invoice.destroy_all` — untouched
- `Transaction.create` (import path) — untouched
- All other SDK resources — untouched
- Callback and promise interfaces — both supported, no signature changes

## Test plan
- [x] All 235 unit tests pass (`npm test`)
- [x] 23 integration tests pass against live API (`test_pip_310.js`)
- [x] Verified envelope wrapping via nock body capture
- [x] Verified backward compatibility (pre-wrapped params not double-wrapped)
- [x] Verified error responses return correct status codes
- [x] Rejection guards on all error tests (no silent passes)
- [x] Verified disable/enable sends correct `{disabled: true/false}` body
- [x] Verified `qs` key is stripped from body and sent as URL query params
- [x] CI green on Node 16, 18, 20

## Testing instructions

> **Account:** `WiktorOnboarding` (ID: `acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate user `wiktor.plaga@chartmogul.com` to find the API key. The test uses data source `ds_45d064ca-fcf8-11f0-903f-33618f80d753` ("Via API 3", Custom) for create/update/delete operations, and `ds_bdb16dbc-d5f3-11f0-b731-f7f85427b781` ("WiktorChartmogulStripe", Stripe) for disable/enable (which is only supported on connector data sources).

```bash
cd chartmogul-node
git checkout wiktor/pip-311-node-sdk-feature-updates
npm install
export CHARTMOGUL_API_KEY='<api_key>'
node
```

### SubscriptionEvent flat param wrapping (create)

```js
const ChartMogul = require('./');
const config = new ChartMogul.Config(process.env.CHARTMOGUL_API_KEY);

// Flat params — SDK auto-wraps into { subscription_event: { ... } }
const event = await ChartMogul.SubscriptionEvent.create(config, {
  customer_external_id: 'cus_TbosMb4qlH97x6',
  data_source_uuid: 'ds_bdb16dbc-d5f3-11f0-b731-f7f85427b781',
  event_type: 'subscription_cancelled',
  event_date: '2026-01-01T00:00:00Z',
  effective_date: '2026-02-01T00:00:00Z',
  external_id: 'test_flat_' + Date.now(),
  subscription_external_id: 'si_TbotiB3CvV3ogI'
});
console.log('Created:', event.id, event.external_id);
```

### SubscriptionEvent envelope backward compat (create)

```js
// Envelope style — SDK detects existing key and does NOT double-wrap
const event2 = await ChartMogul.SubscriptionEvent.create(config, {
  subscription_event: {
    customer_external_id: 'cus_TbosMb4qlH97x6',
    data_source_uuid: 'ds_bdb16dbc-d5f3-11f0-b731-f7f85427b781',
    event_type: 'subscription_cancelled',
    event_date: '2026-01-01T00:00:00Z',
    effective_date: '2026-02-01T00:00:00Z',
    external_id: 'test_env_' + Date.now(),
    subscription_external_id: 'si_TbotiB3CvV3ogI'
  }
});
console.log('Created (envelope):', event2.id);
```

### SubscriptionEvent flat param wrapping (update / delete)

```js
const updated = await ChartMogul.SubscriptionEvent.updateWithParams(config, {
  id: event.id,
  event_type: 'subscription_cancelled'
});
console.log('Updated:', updated.id, updated.event_type);

await ChartMogul.SubscriptionEvent.deleteWithParams(config, { id: event.id });
console.log('Deleted event', event.id);
```

### SubscriptionEvent disable / enable

```js
// Disable (uses Stripe data source event — Custom DS events do not support disable)
const disabled = await ChartMogul.SubscriptionEvent.disable(config, event2.id);
console.log('Disabled:', disabled.disabled); // true

const enabled = await ChartMogul.SubscriptionEvent.enable(config, event2.id);
console.log('Enabled:', enabled.disabled); // false

await ChartMogul.SubscriptionEvent.deleteWithParams(config, { id: event2.id });
```

### Invoice updateStatus

```js
const cust = await ChartMogul.Customer.create(config, {
  data_source_uuid: 'ds_45d064ca-fcf8-11f0-903f-33618f80d753',
  external_id: 'test_cust_' + Date.now(),
  name: 'Test Customer'
});

const extId = 'test_inv_' + Date.now();
const inv = await ChartMogul.Invoice.create(config, cust.uuid, {
  invoices: [{
    external_id: extId,
    date: '2026-01-01T00:00:00Z',
    currency: 'USD',
    due_date: '2026-01-15T00:00:00Z',
    line_items: [{ type: 'one_time', description: 'Test', amount_in_cents: 1000, quantity: 1 }],
    transactions: [{ date: '2026-01-05T00:00:00Z', type: 'payment', result: 'successful' }]
  }]
});

const voided = await ChartMogul.Invoice.updateStatus(config,
  'ds_45d064ca-fcf8-11f0-903f-33618f80d753', extId, { status: 'voided' }
);
console.log('Status:', voided.invoice.status); // 'voided'
```

### Invoice disable / enable (by UUID)

```js
// Disable only works on connector (Stripe/Chargebee/etc.) invoices, not Custom DS
const invs = await ChartMogul.Invoice.all(config);
const stripeInv = invs.invoices.find(i => !i.disabled && i.external_id.startsWith('in_'));

const dis = await ChartMogul.Invoice.disable(config, stripeInv.uuid);
console.log('Disabled:', dis.disabled, 'at:', dis.disabled_at); // true

const en = await ChartMogul.Invoice.enable(config, stripeInv.uuid);
console.log('Re-enabled:', en.disabled); // false
```

### Invoice update by query params (PIP-306)

```js
// PATCH /v1/invoices?data_source_uuid=X&external_id=Y with body
const updated = await ChartMogul.Invoice.update(config, {
  qs: { data_source_uuid: 'ds_45d064ca-fcf8-11f0-903f-33618f80d753', external_id: extId },
  currency: 'EUR'
});
console.log('Updated currency:', updated.currency);
```

### Invoice disable/enable by query params (PIP-306)

```js
// Disable by external_id (connector DS invoices only)
const dis2 = await ChartMogul.Invoice.disableByExternalId(config, {
  data_source_uuid: 'ds_bdb16dbc-d5f3-11f0-b731-f7f85427b781',
  external_id: 'in_1Spq1NBs301LfkCRkuOZDqHZ'
});
console.log('Disabled by ext_id:', dis2.disabled);

const en2 = await ChartMogul.Invoice.enableByExternalId(config, {
  data_source_uuid: 'ds_bdb16dbc-d5f3-11f0-b731-f7f85427b781',
  external_id: 'in_1Spq1NBs301LfkCRkuOZDqHZ'
});
console.log('Re-enabled by ext_id:', en2.disabled);
```

### LineItem query-param endpoints (PIP-306)

```js
// GET line items by data_source_uuid + external_id
const items = await ChartMogul.LineItem.all(config, {
  data_source_uuid: 'ds_bdb16dbc-d5f3-11f0-b731-f7f85427b781',
  external_id: 'il_1St1yTDZd9drsue4W4H8zj5V'
});
console.log('Line items:', items.line_items?.length);

// PATCH line item by query params
const updatedLi = await ChartMogul.LineItem.update(config, {
  qs: { data_source_uuid: 'ds_bdb16dbc-...', external_id: 'il_...' },
  amount_in_cents: 20000
});

// Disable/enable line item
const disLi = await ChartMogul.LineItem.disable(config, {
  data_source_uuid: 'ds_bdb16dbc-...', external_id: 'il_...'
});
const enLi = await ChartMogul.LineItem.enable(config, {
  data_source_uuid: 'ds_bdb16dbc-...', external_id: 'il_...'
});
```

### Transaction query-param endpoints (PIP-306)

```js
// GET transactions by data_source_uuid + external_id
const txns = await ChartMogul.Transaction.all(config, {
  data_source_uuid: 'ds_bdb16dbc-d5f3-11f0-b731-f7f85427b781',
  external_id: 'ch_3St2vHDZd9drsue42v3rkVMC'
});
console.log('Transactions:', txns.transactions?.length);

// Disable/enable transaction
const disTx = await ChartMogul.Transaction.disable(config, {
  data_source_uuid: 'ds_bdb16dbc-...', external_id: 'ch_...'
});
const enTx = await ChartMogul.Transaction.enable(config, {
  data_source_uuid: 'ds_bdb16dbc-...', external_id: 'ch_...'
});
```

### Account.retrieve include param validation

```js
// Valid include — no warning
const acct = await ChartMogul.Account.retrieve(config, {
  include: 'refund_handling,churn_recognition'
});
console.log('Refund handling:', acct.refund_handling);

// Invalid include — prints console warning, still makes the request
const acct2 = await ChartMogul.Account.retrieve(config, {
  include: 'bogus_field'
});
```

### Cleanup

```js
await ChartMogul.Customer.destroy(config, cust.uuid);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)