### PR TITLE
Add Bulk JSON Import support

### DIFF
--- a/lib/chartmogul.js
+++ b/lib/chartmogul.js
@@ -24,6 +24,8 @@ const Tag = require('./chartmogul/tag');
 
 const Account = require('./chartmogul/account');
 
+const JsonImport = require('./chartmogul/json-import');
+
 const Config = require('./chartmogul/config');
 
 // Deprecated modules
@@ -40,6 +42,7 @@ const ChartMogul = {
   Enrichment,
   Import,
   Invoice,
+  JsonImport,
   LineItem,
   Metrics,
   Opportunity,

--- a/lib/chartmogul/json-import.js
+++ b/lib/chartmogul/json-import.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Resource = require('./resource.js');
+
+class JsonImport extends Resource {
+  static get path () {
+    return '/v1/data_sources{/dataSourceUuid}/json_imports{/importId}';
+  }
+}
+
+JsonImport.create = Resource._method('POST', '/v1/data_sources{/dataSourceUuid}/json_imports');
+JsonImport.retrieve = Resource._method('GET', '/v1/data_sources{/dataSourceUuid}/json_imports{/importId}');
+
+module.exports = JsonImport;

--- a/test/chartmogul/json-import.js
+++ b/test/chartmogul/json-import.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const ChartMogul = require('../../lib/chartmogul');
+const config = new ChartMogul.Config('token');
+const expect = require('chai').expect;
+const nock = require('nock');
+const JsonImport = ChartMogul.JsonImport;
+
+/* eslint-disable camelcase */
+const dsUuid = 'ds_1fm3eaac-62d0-31ec-clf4-4bf0mbe81aba';
+
+const importBody = {
+  external_id: 'ds_import_1',
+  customers: [
+    {
+      external_id: 'scus_0001',
+      name: 'Andrew Jones',
+      email: 'andrew@example.com'
+    }
+  ],
+  plans: [
+    {
+      name: 'Gold Biannual',
+      external_id: 'gold_biannual',
+      interval_count: 6,
+      interval_unit: 'month'
+    }
+  ]
+};
+
+const importResponse = {
+  id: '4815d987-1234-11ee-a987-978df45c5114',
+  data_source_uuid: dsUuid,
+  status: 'queued',
+  external_id: 'ds_import_1',
+  status_details: {},
+  created_at: '2023-06-01T23:55:23Z',
+  updated_at: '2023-06-01T23:55:23Z'
+};
+
+const trackResponse = {
+  id: '4815d987-1234-11ee-a987-978df45c5114',
+  data_source_uuid: dsUuid,
+  status: 'completed',
+  external_id: 'ds_import_1',
+  status_details: {
+    plans: { status: 'imported' },
+    scus_0001: { status: 'imported' }
+  },
+  created_at: '2023-06-01T23:55:23Z',
+  updated_at: '2023-06-01T23:56:00Z'
+};
+/* eslint-enable camelcase */
+
+describe('JsonImport', () => {
+  it('should create a bulk import', () => {
+    nock(config.API_BASE)
+      .post(`/v1/data_sources/${dsUuid}/json_imports`)
+      .reply(200, importResponse);
+
+    return JsonImport.create(config, dsUuid, importBody)
+      .then(res => {
+        expect(res).to.have.property('id');
+        expect(res.status).to.equal('queued');
+        expect(res.external_id).to.equal('ds_import_1');
+      });
+  });
+
+  it('should track import status', () => {
+    const importId = 'ds_import_1';
+
+    nock(config.API_BASE)
+      .get(`/v1/data_sources/${dsUuid}/json_imports/${importId}`)
+      .reply(200, trackResponse);
+
+    return JsonImport.retrieve(config, dsUuid, importId)
+      .then(res => {
+        expect(res).to.have.property('id');
+        expect(res.status).to.equal('completed');
+        expect(res.status_details).to.be.an('object');
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `JsonImport.create()` for bulk importing customers, plans, invoices, line items, transactions and subscription events via `POST /data_sources/{uuid}/json_imports`
- Adds `JsonImport.retrieve()` for tracking import status via `GET /data_sources/{uuid}/json_imports/{id}`
- Exports new `JsonImport` module from main entry point

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added new `JsonImport` resource module | No — new file, new export |
| Added `JsonImport` to main `ChartMogul` exports | No — additive |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```javascript
const ChartMogul = require('chartmogul-node');
const config = new ChartMogul.Config('YOUR_API_KEY');

// Import data in bulk
const result = await ChartMogul.JsonImport.create(config, 'ds_...', {
  external_id: 'ds_import_1',
  customers: [{ external_id: 'cus_001', name: 'Test Customer' }],
  plans: [{ name: 'Gold', external_id: 'gold', interval_count: 1, interval_unit: 'month' }]
});
console.log(result.status); // 'queued'

// Track import status
const status = await ChartMogul.JsonImport.retrieve(config, 'ds_...', 'ds_import_1');
console.log(status.status); // 'queued' | 'processing' | 'completed'
```

## Test plan
- [x] Unit tests added for create and retrieve
- [x] Verify against live API with a test data source

🤖 Generated with [Claude Code](https://claude.com/claude-code)