### PR TITLE
Add CSV Upload support

### DIFF
--- a/lib/chartmogul.js
+++ b/lib/chartmogul.js
@@ -24,6 +24,8 @@ const Tag = require('./chartmogul/tag');
 
 const Account = require('./chartmogul/account');
 
+const Upload = require('./chartmogul/upload');
+
 const Config = require('./chartmogul/config');
 
 // Deprecated modules
@@ -51,6 +53,7 @@ const ChartMogul = {
   Tag,
   Task,
   Transaction,
+  Upload,
   Account
 };
 

--- a/lib/chartmogul/upload.js
+++ b/lib/chartmogul/upload.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const errors = require('./errors');
+const util = require('./util');
+const Config = require('./config');
+
+class Upload {
+  static create (config, dataSourceUuid, data, callback) {
+    const promise = new Promise((resolve, reject) => {
+      if (!(config instanceof Config)) {
+        const error = new errors.ConfigurationError(
+          'First argument should be instance of ChartMogul.Config class'
+        );
+        return reject(error);
+      }
+
+      const uri = `/v1/data_sources/${dataSourceUuid}/uploads`;
+
+      const formData = {};
+      if (data.file) formData.file = data.file;
+      if (data.type) formData.type = data.type;
+      if (data.batch_name) formData.batch_name = data.batch_name;
+
+      const options = {
+        uri,
+        method: 'POST',
+        formData,
+        qs: {},
+        auth: {
+          user: config.getApiKey(),
+          pass: '',
+          sendImmediately: true
+        },
+        baseUrl: config.API_BASE,
+        headers: {
+          'User-Agent': 'chartmogul-node/' + config.VERSION
+        }
+      };
+
+      util.retryRequest(config.retries, options, (error, response, body) => {
+        if (error) {
+          return reject(error);
+        }
+
+        let err = null;
+        switch (response.statusCode) {
+          case 400:
+            err = new errors.SchemaInvalidError(
+              "JSON schema validation hasn't passed.",
+              response.statusCode,
+              body
+            );
+            break;
+          case 401:
+          case 403:
+            err = new errors.ForbiddenError(
+              'The requested action is forbidden.',
+              response.statusCode,
+              body
+            );
+            break;
+          case 404:
+            err = new errors.NotFoundError(
+              'The requested Upload could not be found.',
+              response.statusCode,
+              body
+            );
+            break;
+          case 422:
+            err = new errors.ResourceInvalidError(
+              'The Upload could not be created or updated.',
+              response.statusCode,
+              body
+            );
+            break;
+          case 200:
+          case 201:
+          case 202:
+          case 204:
+            break;
+          default:
+            err = new errors.ChartMogulError(
+              'Upload request error has occurred.',
+              response.statusCode,
+              body
+            );
+            break;
+        }
+        if (err) {
+          return reject(err);
+        }
+        resolve(body);
+      });
+    });
+
+    if (callback && typeof callback === 'function') {
+      promise.then(callback.bind(null, null), callback);
+      return;
+    }
+
+    return promise;
+  }
+}
+
+module.exports = Upload;

--- a/lib/chartmogul/util/retry.js
+++ b/lib/chartmogul/util/retry.js
@@ -51,8 +51,20 @@ module.exports = function retryRequest (retries, options, cb) {
       .auth(options.auth.user, options.auth.pass)
       .set(options.headers)
       .timeout({ response: 30000, deadline: 120000 })
-      .query(options.qs)
-      .send(options.body);
+      .query(options.qs);
+
+    if (options.formData) {
+      // Multipart form-data upload (e.g. CSV file upload)
+      for (const [key, value] of Object.entries(options.formData)) {
+        if (key === 'file') {
+          request.attach(key, value);
+        } else {
+          request.field(key, value);
+        }
+      }
+    } else {
+      request.send(options.body);
+    }
 
     request.end((err, res) => {
       if (operation.retry(retryOnStatus(res) || retryOnNetworkError(err))) {

--- a/test/chartmogul/upload.js
+++ b/test/chartmogul/upload.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const ChartMogul = require('../../lib/chartmogul');
+const config = new ChartMogul.Config('token');
+const expect = require('chai').expect;
+const nock = require('nock');
+const path = require('path');
+const fs = require('fs');
+const Upload = ChartMogul.Upload;
+
+/* eslint-disable camelcase */
+const dsUuid = 'ds_ade45e52-47a4-231a-1ed2-eb6b9e541213';
+
+const uploadResponse = {
+  id: 12345,
+  status: 'queued',
+  created_at: '2026-03-19T10:00:00Z',
+  updated_at: '2026-03-19T10:00:00Z',
+  error_count: 0,
+  processed_count: 0
+};
+/* eslint-enable camelcase */
+
+describe('Upload', () => {
+  it('should upload a CSV file', () => {
+    // Create a temporary CSV file for testing
+    const tmpFile = path.join(__dirname, 'test-upload.csv');
+    fs.writeFileSync(tmpFile, 'name,email\nJohn,john@example.com\n');
+
+    nock(config.API_BASE)
+      .post(`/v1/data_sources/${dsUuid}/uploads`)
+      .reply(200, uploadResponse);
+
+    return Upload.create(config, dsUuid, {
+      file: tmpFile,
+      type: 'customers',
+      batch_name: 'test_import'
+    })
+      .then(res => {
+        expect(res).to.have.property('id', 12345);
+        expect(res.status).to.equal('queued');
+      })
+      .finally(() => {
+        fs.unlinkSync(tmpFile);
+      });
+  });
+
+  it('should reject with ConfigurationError for invalid config', () => {
+    return Upload.create('not-a-config', dsUuid, { file: '/tmp/test.csv', type: 'customers' })
+      .then(() => { throw new Error('Expected rejection'); })
+      .catch(e => {
+        if (e.message === 'Expected rejection') throw e;
+        expect(e).to.be.instanceOf(ChartMogul.ConfigurationError);
+      });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `Upload.create()` for uploading CSV files to data sources via `POST /data_sources/{uuid}/uploads` (multipart/form-data)
- Adds `formData` support to the retry utility for multipart file uploads
- Exports new `Upload` module from main entry point

## Test plan
- [x] Unit tests added for create and config validation
- [ ] Verify multipart upload against live API with a test CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)