### PR TITLE
Add Line Item UUID-based endpoints and create method

### DIFF
--- a/lib/chartmogul/line-item.js
+++ b/lib/chartmogul/line-item.js
@@ -4,32 +4,71 @@ const Resource = require('./resource.js');
 
 class LineItem extends Resource {
   static get path () {
-    return '/v1/line_items';
+    return '/v1/line_items{/lineItemUuid}';
   }
 }
 
-// GET /v1/line_items?data_source_uuid=X&external_id=Y
+// Create: POST /v1/import/invoices/:invoiceUuid/line_items
+LineItem.create = Resource._method('POST', '/v1/import/invoices{/invoiceUuid}/line_items');
+
+// Retrieve by UUID: GET /v1/line_items/:lineItemUuid
+// (inherited from Resource via path template)
+
+// List/get by query params: GET /v1/line_items?data_source_uuid=X&external_id=Y
 LineItem.all = Resource._method('GET', '/v1/line_items');
 
-// PATCH /v1/line_items?data_source_uuid=X&external_id=Y  { body }
+// Update by UUID: PATCH /v1/line_items/:lineItemUuid
+// (inherited `modify` from Resource via path template)
+
+// Update by query params: PATCH /v1/line_items?data_source_uuid=X&external_id=Y  { body }
 LineItem.update = Resource._method('PATCH', '/v1/line_items');
 
-// DELETE /v1/line_items?data_source_uuid=X&external_id=Y
-LineItem.destroy = Resource._method('DELETE', '/v1/line_items');
+// Delete by UUID: DELETE /v1/line_items/:lineItemUuid
+LineItem.destroy = Resource._method('DELETE', '/v1/line_items{/lineItemUuid}');
 
-// PATCH /v1/line_items/disabled_state?data_source_uuid=X&external_id=Y  { disabled: bool }
-LineItem._setDisabledState = Resource._method('PATCH', '/v1/line_items/disabled_state');
-LineItem.disable = function (config, params, callback) {
+// Delete by query params: DELETE /v1/line_items?data_source_uuid=X&external_id=Y
+LineItem.destroyByExternalId = Resource._method('DELETE', '/v1/line_items');
+
+// Disable/enable by UUID: PATCH /v1/line_items/:lineItemUuid/disabled_state
+LineItem._setDisabledState = Resource._method('PATCH', '/v1/line_items{/lineItemUuid}/disabled_state');
+LineItem.disable = function (config, uuidOrParams, callback) {
+  if (typeof uuidOrParams === 'string') {
+    const args = [config, uuidOrParams, { disabled: true }];
+    if (typeof callback === 'function') args.push(callback);
+    return LineItem._setDisabledState.apply(this, args);
+  }
+  // query-param variant
+  const data = { qs: uuidOrParams, disabled: true };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return LineItem._setDisabledStateByExternalId.apply(this, args);
+};
+LineItem.enable = function (config, uuidOrParams, callback) {
+  if (typeof uuidOrParams === 'string') {
+    const args = [config, uuidOrParams, { disabled: false }];
+    if (typeof callback === 'function') args.push(callback);
+    return LineItem._setDisabledState.apply(this, args);
+  }
+  // query-param variant
+  const data = { qs: uuidOrParams, disabled: false };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return LineItem._setDisabledStateByExternalId.apply(this, args);
+};
+
+// Disable/enable by query params: PATCH /v1/line_items/disabled_state?data_source_uuid=X&external_id=Y
+LineItem._setDisabledStateByExternalId = Resource._method('PATCH', '/v1/line_items/disabled_state');
+LineItem.disableByExternalId = function (config, params, callback) {
   const data = { qs: params, disabled: true };
   const args = [config, data];
   if (typeof callback === 'function') args.push(callback);
-  return LineItem._setDisabledState.apply(this, args);
+  return LineItem._setDisabledStateByExternalId.apply(this, args);
 };
-LineItem.enable = function (config, params, callback) {
+LineItem.enableByExternalId = function (config, params, callback) {
   const data = { qs: params, disabled: false };
   const args = [config, data];
   if (typeof callback === 'function') args.push(callback);
-  return LineItem._setDisabledState.apply(this, args);
+  return LineItem._setDisabledStateByExternalId.apply(this, args);
 };
 
 module.exports = LineItem;

--- a/test/chartmogul/line-item.js
+++ b/test/chartmogul/line-item.js
@@ -22,6 +22,102 @@ const lineItemResponse = {
 /* eslint-enable camelcase */
 
 describe('LineItem', () => {
+  it('should create a line item', () => {
+    const invoiceUuid = 'inv_79eaad44-3379-4239-af83-2e0047dbebe6';
+
+    /* eslint-disable camelcase */
+    const postBody = {
+      type: 'subscription',
+      amount_in_cents: 10000,
+      quantity: 1,
+      external_id: 'li_ext_id_00762',
+      subscription_external_id: 'sub_added_line_item_via_api_1',
+      plan_uuid: 'pl_3eb4efb2-d101-4dce-a664-be271b0da4de',
+      service_period_start: '2022-11-01T00:00:00.000Z',
+      service_period_end: '2022-12-01T00:00:00.000Z'
+    };
+    /* eslint-enable camelcase */
+
+    nock(config.API_BASE)
+      .post(`/v1/import/invoices/${invoiceUuid}/line_items`)
+      .reply(200, {
+        ...lineItemResponse,
+        ...postBody
+      });
+
+    return LineItem.create(config, invoiceUuid, postBody)
+      .then(res => {
+        expect(res).to.have.property('uuid');
+        expect(res.type).to.equal('subscription');
+      });
+  });
+
+  it('should retrieve a line item by UUID', () => {
+    const uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+
+    nock(config.API_BASE)
+      .get(`/v1/line_items/${uuid}`)
+      .reply(200, lineItemResponse);
+
+    return LineItem.retrieve(config, uuid)
+      .then(res => {
+        expect(res).to.have.property('uuid', uuid);
+        expect(res.type).to.equal('subscription');
+      });
+  });
+
+  it('should update a line item by UUID', () => {
+    const uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+
+    nock(config.API_BASE)
+      .patch(`/v1/line_items/${uuid}`)
+      .reply(200, { ...lineItemResponse, amount_in_cents: 20000 });
+
+    return LineItem.modify(config, uuid, { amount_in_cents: 20000 })
+      .then(res => {
+        expect(res.amount_in_cents).to.equal(20000);
+      });
+  });
+
+  it('should delete a line item by UUID', () => {
+    const uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+
+    nock(config.API_BASE)
+      .delete(`/v1/line_items/${uuid}`)
+      .reply(204, {});
+
+    return LineItem.destroy(config, uuid)
+      .then(res => {
+        expect(res).to.be.an('object');
+      });
+  });
+
+  it('should disable a line item by UUID', async () => {
+    const uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+    let requestBody;
+
+    nock(config.API_BASE)
+      .patch(`/v1/line_items/${uuid}/disabled_state`, body => { requestBody = body; return true; })
+      .reply(200, { ...lineItemResponse, disabled: true });
+
+    const res = await LineItem.disable(config, uuid);
+    expect(res.disabled).to.equal(true);
+    expect(requestBody).to.deep.equal({ disabled: true });
+  });
+
+  it('should enable a line item by UUID', async () => {
+    const uuid = 'li_592f4699-107b-41b9-b7bc-a2aa2ca7a67b';
+    let requestBody;
+
+    nock(config.API_BASE)
+      .patch(`/v1/line_items/${uuid}/disabled_state`, body => { requestBody = body; return true; })
+      .reply(200, { ...lineItemResponse, disabled: false });
+
+    const res = await LineItem.enable(config, uuid);
+    expect(res.disabled).to.equal(false);
+    expect(requestBody).to.deep.equal({ disabled: false });
+  });
+
   it('should get line items by data_source_uuid and external_id', () => {
     nock(config.API_BASE)
       .get('/v1/line_items')
@@ -60,7 +156,7 @@ describe('LineItem', () => {
       .query(queryParams)
       .reply(204, {});
 
-    const res = await LineItem.destroy(config, { qs: queryParams });
+    const res = await LineItem.destroyByExternalId(config, { qs: queryParams });
     expect(res).to.be.an('object');
   });
 
@@ -71,7 +167,7 @@ describe('LineItem', () => {
       .query(queryParams)
       .reply(200, { ...lineItemResponse, disabled: true });
 
-    const res = await LineItem.disable(config, queryParams);
+    const res = await LineItem.disableByExternalId(config, queryParams);
     expect(res.disabled).to.equal(true);
     expect(requestBody).to.deep.equal({ disabled: true });
   });
@@ -83,7 +179,7 @@ describe('LineItem', () => {
       .query(queryParams)
       .reply(200, { ...lineItemResponse, disabled: false });
 
-    const res = await LineItem.enable(config, queryParams);
+    const res = await LineItem.enableByExternalId(config, queryParams);
     expect(res.disabled).to.equal(false);
     expect(requestBody).to.deep.equal({ disabled: false });
   });


### PR DESCRIPTION
## Summary
- Adds `LineItem.create()` for creating line items via `POST /import/invoices/{uuid}/line_items`
- Adds UUID-based `retrieve`, `modify`, `destroy`, `disable`/`enable` for line items
- Preserves existing query-param-based methods, renaming delete/disable to `destroyByExternalId`/`disableByExternalId`/`enableByExternalId`
- `disable`/`enable` auto-detect UUID (string) vs query-param (object) usage

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Changed `LineItem.path` from `/v1/line_items` to `/v1/line_items{/lineItemUuid}` | No — URI template expands to same path when no UUID arg given |
| Added `LineItem.create` override | No — previous inherited `create` went to wrong path (`/v1/line_items` POST), so it was non-functional |
| Renamed old `LineItem.destroy` to `LineItem.destroyByExternalId` | **Yes** — callers using `LineItem.destroy(config, { qs: ... })` must switch to `destroyByExternalId`. `destroy` now expects a UUID string. |
| Renamed old `LineItem.disable`/`enable` to `disableByExternalId`/`enableByExternalId` | **Partial** — `disable`/`enable` now auto-detect: string arg → UUID path, object arg → query-param path. Existing callers passing an object still work. |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```javascript
const ChartMogul = require('chartmogul-node');
const config = new ChartMogul.Config('YOUR_API_KEY');

// Create a line item on an invoice
const li = await ChartMogul.LineItem.create(config, 'inv_...', {
  type: 'subscription',
  amount_in_cents: 10000,
  quantity: 1,
  subscription_external_id: 'sub_001',
  plan_uuid: 'pl_...',
  service_period_start: '2026-01-01T00:00:00.000Z',
  service_period_end: '2026-02-01T00:00:00.000Z'
});

// Retrieve by UUID
const retrieved = await ChartMogul.LineItem.retrieve(config, 'li_...');

// Update by UUID
await ChartMogul.LineItem.modify(config, 'li_...', { amount_in_cents: 20000 });

// Delete by UUID
await ChartMogul.LineItem.destroy(config, 'li_...');

// Disable by UUID
await ChartMogul.LineItem.disable(config, 'li_...');

// Enable by UUID
await ChartMogul.LineItem.enable(config, 'li_...');

// Query-param variants still work
const items = await ChartMogul.LineItem.all(config, {
  data_source_uuid: 'ds_...', external_id: 'li_ext_...'
});
await ChartMogul.LineItem.disableByExternalId(config, {
  data_source_uuid: 'ds_...', external_id: 'li_ext_...'
});
```

## Test plan
- [x] Unit tests added for all new UUID-based methods (create, retrieve, modify, destroy, disable, enable)
- [x] Existing query-param tests preserved and updated
- [x] Verify against live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)