### PR TITLE
Add Transaction UUID-based endpoints

### DIFF
--- a/lib/chartmogul/transaction.js
+++ b/lib/chartmogul/transaction.js
@@ -8,28 +8,67 @@ class Transaction extends Resource {
   }
 }
 
-// GET /v1/transactions?data_source_uuid=X&external_id=Y
+// Create: POST /v1/import/invoices/:invoiceUuid/transactions
+// (inherited from Resource via path template)
+
+// Retrieve by UUID: GET /v1/transactions/:transactionUuid
+Transaction.retrieve = Resource._method('GET', '/v1/transactions{/transactionUuid}');
+
+// List/get by query params: GET /v1/transactions?data_source_uuid=X&external_id=Y
 Transaction.all = Resource._method('GET', '/v1/transactions');
 
-// PATCH /v1/transactions?data_source_uuid=X&external_id=Y  { body }
+// Update by UUID: PATCH /v1/transactions/:transactionUuid
+Transaction.modify = Resource._method('PATCH', '/v1/transactions{/transactionUuid}');
+
+// Update by query params: PATCH /v1/transactions?data_source_uuid=X&external_id=Y  { body }
 Transaction.update = Resource._method('PATCH', '/v1/transactions');
 
-// DELETE /v1/transactions?data_source_uuid=X&external_id=Y
-Transaction.destroy = Resource._method('DELETE', '/v1/transactions');
+// Delete by UUID: DELETE /v1/transactions/:transactionUuid
+Transaction.destroy = Resource._method('DELETE', '/v1/transactions{/transactionUuid}');
 
-// PATCH /v1/transactions/disabled_state?data_source_uuid=X&external_id=Y  { disabled: bool }
-Transaction._setDisabledState = Resource._method('PATCH', '/v1/transactions/disabled_state');
-Transaction.disable = function (config, params, callback) {
+// Delete by query params: DELETE /v1/transactions?data_source_uuid=X&external_id=Y
+Transaction.destroyByExternalId = Resource._method('DELETE', '/v1/transactions');
+
+// Disable/enable by UUID: PATCH /v1/transactions/:transactionUuid/disabled_state
+Transaction._setDisabledState = Resource._method('PATCH', '/v1/transactions{/transactionUuid}/disabled_state');
+Transaction.disable = function (config, uuidOrParams, callback) {
+  if (typeof uuidOrParams === 'string') {
+    const args = [config, uuidOrParams, { disabled: true }];
+    if (typeof callback === 'function') args.push(callback);
+    return Transaction._setDisabledState.apply(this, args);
+  }
+  // query-param variant
+  const data = { qs: uuidOrParams, disabled: true };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return Transaction._setDisabledStateByExternalId.apply(this, args);
+};
+Transaction.enable = function (config, uuidOrParams, callback) {
+  if (typeof uuidOrParams === 'string') {
+    const args = [config, uuidOrParams, { disabled: false }];
+    if (typeof callback === 'function') args.push(callback);
+    return Transaction._setDisabledState.apply(this, args);
+  }
+  // query-param variant
+  const data = { qs: uuidOrParams, disabled: false };
+  const args = [config, data];
+  if (typeof callback === 'function') args.push(callback);
+  return Transaction._setDisabledStateByExternalId.apply(this, args);
+};
+
+// Disable/enable by query params: PATCH /v1/transactions/disabled_state?data_source_uuid=X&external_id=Y
+Transaction._setDisabledStateByExternalId = Resource._method('PATCH', '/v1/transactions/disabled_state');
+Transaction.disableByExternalId = function (config, params, callback) {
   const data = { qs: params, disabled: true };
   const args = [config, data];
   if (typeof callback === 'function') args.push(callback);
-  return Transaction._setDisabledState.apply(this, args);
+  return Transaction._setDisabledStateByExternalId.apply(this, args);
 };
-Transaction.enable = function (config, params, callback) {
+Transaction.enableByExternalId = function (config, params, callback) {
   const data = { qs: params, disabled: false };
   const args = [config, data];
   if (typeof callback === 'function') args.push(callback);
-  return Transaction._setDisabledState.apply(this, args);
+  return Transaction._setDisabledStateByExternalId.apply(this, args);
 };
 
 module.exports = Transaction;

--- a/test/chartmogul/transaction.js
+++ b/test/chartmogul/transaction.js
@@ -35,6 +35,83 @@ describe('Transaction', () => {
         expect(res).to.have.property('uuid');
       });
   });
+
+  it('should retrieve a transaction by UUID', () => {
+    const uuid = 'tr_73b392ce-f141-4d14-97f0-6baf93d8bf68';
+
+    /* eslint-disable camelcase */
+    nock(config.API_BASE)
+      .get(`/v1/transactions/${uuid}`)
+      .reply(200, {
+        uuid,
+        external_id: 'trans_00241',
+        type: 'refund',
+        date: '2015-12-25T18:10:00.000Z',
+        result: 'successful'
+      });
+    /* eslint-enable camelcase */
+
+    return Transaction.retrieve(config, uuid)
+      .then(res => {
+        expect(res).to.have.property('uuid', uuid);
+        expect(res.type).to.equal('refund');
+      });
+  });
+
+  it('should update a transaction by UUID', () => {
+    const uuid = 'tr_73b392ce-f141-4d14-97f0-6baf93d8bf68';
+
+    nock(config.API_BASE)
+      .patch(`/v1/transactions/${uuid}`)
+      .reply(200, {
+        uuid,
+        result: 'failed'
+      });
+
+    return Transaction.modify(config, uuid, { result: 'failed' })
+      .then(res => {
+        expect(res.result).to.equal('failed');
+      });
+  });
+
+  it('should delete a transaction by UUID', () => {
+    const uuid = 'tr_73b392ce-f141-4d14-97f0-6baf93d8bf68';
+
+    nock(config.API_BASE)
+      .delete(`/v1/transactions/${uuid}`)
+      .reply(204, {});
+
+    return Transaction.destroy(config, uuid)
+      .then(res => {
+        expect(res).to.be.an('object');
+      });
+  });
+
+  it('should disable a transaction by UUID', async () => {
+    const uuid = 'tr_73b392ce-f141-4d14-97f0-6baf93d8bf68';
+    let requestBody;
+
+    nock(config.API_BASE)
+      .patch(`/v1/transactions/${uuid}/disabled_state`, body => { requestBody = body; return true; })
+      .reply(200, { uuid, disabled: true });
+
+    const res = await Transaction.disable(config, uuid);
+    expect(res.disabled).to.equal(true);
+    expect(requestBody).to.deep.equal({ disabled: true });
+  });
+
+  it('should enable a transaction by UUID', async () => {
+    const uuid = 'tr_73b392ce-f141-4d14-97f0-6baf93d8bf68';
+    let requestBody;
+
+    nock(config.API_BASE)
+      .patch(`/v1/transactions/${uuid}/disabled_state`, body => { requestBody = body; return true; })
+      .reply(200, { uuid, disabled: false });
+
+    const res = await Transaction.enable(config, uuid);
+    expect(res.disabled).to.equal(false);
+    expect(requestBody).to.deep.equal({ disabled: false });
+  });
 });
 
 /* eslint-disable camelcase */
@@ -91,7 +168,7 @@ describe('Transaction query params', () => {
       .query(queryParams)
       .reply(204, {});
 
-    const res = await Transaction.destroy(config, { qs: queryParams });
+    const res = await Transaction.destroyByExternalId(config, { qs: queryParams });
     expect(res).to.be.an('object');
   });
 
@@ -102,7 +179,7 @@ describe('Transaction query params', () => {
       .query(queryParams)
       .reply(200, { ...transactionResponse, disabled: true });
 
-    const res = await Transaction.disable(config, queryParams);
+    const res = await Transaction.disableByExternalId(config, queryParams);
     expect(res.disabled).to.equal(true);
     expect(requestBody).to.deep.equal({ disabled: true });
   });
@@ -114,7 +191,7 @@ describe('Transaction query params', () => {
       .query(queryParams)
       .reply(200, { ...transactionResponse, disabled: false });
 
-    const res = await Transaction.enable(config, queryParams);
+    const res = await Transaction.enableByExternalId(config, queryParams);
     expect(res.disabled).to.equal(false);
     expect(requestBody).to.deep.equal({ disabled: false });
   });


### PR DESCRIPTION
## Summary
- Adds UUID-based `retrieve`, `modify`, `destroy`, `disable`/`enable` for transactions
- Preserves existing query-param-based methods, renaming delete/disable to `destroyByExternalId`/`disableByExternalId`/`enableByExternalId`
- `disable`/`enable` auto-detect UUID (string) vs query-param (object) usage

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added `Transaction.retrieve` override (`GET /transactions/{uuid}`) | No — previous inherited `retrieve` went to import path, so it was non-functional for standalone retrieval |
| Added `Transaction.modify` (`PATCH /transactions/{uuid}`) | No — new method |
| Renamed old `Transaction.destroy` to `Transaction.destroyByExternalId` | **Yes** — callers using `Transaction.destroy(config, { qs: ... })` must switch to `destroyByExternalId`. `destroy` now expects a UUID string. |
| Renamed old `Transaction.disable`/`enable` to `disableByExternalId`/`enableByExternalId` | **Partial** — `disable`/`enable` now auto-detect: string arg → UUID path, object arg → query-param path. Existing callers passing an object still work. |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```javascript
const ChartMogul = require('chartmogul-node');
const config = new ChartMogul.Config('YOUR_API_KEY');

// Retrieve by UUID
const tx = await ChartMogul.Transaction.retrieve(config, 'tr_...');
console.log(tx.uuid, tx.type, tx.result);

// Update by UUID
await ChartMogul.Transaction.modify(config, 'tr_...', { result: 'failed' });

// Delete by UUID
await ChartMogul.Transaction.destroy(config, 'tr_...');

// Disable by UUID
await ChartMogul.Transaction.disable(config, 'tr_...');

// Enable by UUID
await ChartMogul.Transaction.enable(config, 'tr_...');

// Query-param variants still work
const txs = await ChartMogul.Transaction.all(config, {
  data_source_uuid: 'ds_...', external_id: 'tr_ext_...'
});
await ChartMogul.Transaction.disableByExternalId(config, {
  data_source_uuid: 'ds_...', external_id: 'tr_ext_...'
});
```

## Test plan
- [x] Unit tests added for all new UUID-based methods (retrieve, modify, destroy, disable, enable)
- [x] Existing query-param and create tests preserved
- [x] Verify against live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)