### PR TITLE
Add Invoice UUID-based update

### DIFF
--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -55,7 +55,10 @@ Invoice.enable = function (config, uuid, callback) {
   return Invoice._setDisabledState.apply(this, args);
 };
 
-// PATCH /v1/invoices?data_source_uuid=X&external_id=Y  { body }
+// Update by UUID: PATCH /v1/invoices/:uuid
+Invoice.modify = Resource._method('PATCH', '/v1/invoices{/uuid}');
+
+// Update by query params: PATCH /v1/invoices?data_source_uuid=X&external_id=Y  { body }
 Invoice.update = Resource._method('PATCH', '/v1/invoices');
 
 // DELETE /v1/invoices?data_source_uuid=X&external_id=Y

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -418,6 +418,28 @@ describe('Invoices', () => {
       });
   });
 
+  it('should update an invoice by UUID', () => {
+    const invoiceUuid = 'inv_cff3a63c-3915-435e-a675-85a8a8ef4454';
+
+    let requestBody;
+    nock(config.API_BASE)
+      .patch('/v1/invoices/' + invoiceUuid, body => { requestBody = body; return true; })
+      .reply(200, {
+        /* eslint-disable camelcase */
+        uuid: invoiceUuid,
+        external_id: 'INV0001',
+        currency: 'EUR'
+        /* eslint-enable camelcase */
+      });
+
+    return Invoice.modify(config, invoiceUuid, { currency: 'EUR' })
+      .then(res => {
+        expect(res.uuid).to.equal(invoiceUuid);
+        expect(res.currency).to.equal('EUR');
+        expect(requestBody).to.have.property('currency', 'EUR');
+      });
+  });
+
   it('should retrieve an invoice', () => {
     const payload = { external_id: 'some_invoice_id' };
     nock(config.API_BASE)


### PR DESCRIPTION
## Summary
- Adds `Invoice.modify()` for updating invoices by UUID via `PATCH /invoices/{uuid}`
- Existing query-param-based `Invoice.update()` is preserved

## Backwards compatibility

| Change | Breaking? |
|---|---|
| Added `Invoice.modify` method (`PATCH /invoices/{uuid}`) | No — new method, does not affect existing `Invoice.update` |

## Testing instructions

Test account: **WiktorOnboarding** (`acc_d0ea225e-f0f1-40ab-92cf-659dce5f2b76`). Impersonate `wiktor@chartmogul.com` for API key.

```javascript
const ChartMogul = require('chartmogul-node');
const config = new ChartMogul.Config('YOUR_API_KEY');

// Update invoice by UUID
const updated = await ChartMogul.Invoice.modify(config, 'inv_...', {
  currency: 'EUR'
});
console.log(updated.uuid, updated.currency);

// Query-param update still works
await ChartMogul.Invoice.update(config, {
  qs: { data_source_uuid: 'ds_...', external_id: 'INV0001' },
  currency: 'EUR'
});
```

## Test plan
- [x] Unit test added for modify by UUID
- [x] All existing invoice tests pass
- [x] Verify against live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)