### PR TITLE
Rename snake_case methods to camelCase

### DIFF
--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -9,21 +9,26 @@ class Invoice extends Resource {
 }
 
 // @Override
-Invoice.all_customer = Invoice.all;
+Invoice.allCustomer = Invoice.all;
 
-Invoice.all_any = Resource._method('GET', '/v1/invoices');
+Invoice.allAny = Resource._method('GET', '/v1/invoices');
 
 Invoice.all = function (config, params) {
   if (typeof params === 'string') {
-    return Invoice.all_customer.apply(this, arguments);
+    return Invoice.allCustomer.apply(this, arguments);
   } else {
-    return Invoice.all_any.apply(this, arguments);
+    return Invoice.allAny.apply(this, arguments);
   }
 };
 
 Invoice.destroy = Resource._method('DELETE', '/v1/invoices{/uuid}');
 
-Invoice.destroy_all = Resource._method('DELETE', 'v1/data_sources{/data_source_uuid}/customers{/customer_uuid}/invoices');
+Invoice.destroyAll = Resource._method('DELETE', 'v1/data_sources{/data_source_uuid}/customers{/customer_uuid}/invoices');
+
+// Deprecated snake_case aliases
+Invoice.all_customer = Invoice.allCustomer;
+Invoice.all_any = Invoice.allAny;
+Invoice.destroy_all = Invoice.destroyAll;
 
 Invoice.retrieve = Resource._method('GET', '/v1/invoices{/uuid}');
 

--- a/lib/chartmogul/invoice.js
+++ b/lib/chartmogul/invoice.js
@@ -26,9 +26,18 @@ Invoice.destroy = Resource._method('DELETE', '/v1/invoices{/uuid}');
 Invoice.destroyAll = Resource._method('DELETE', 'v1/data_sources{/data_source_uuid}/customers{/customer_uuid}/invoices');
 
 // Deprecated snake_case aliases
-Invoice.all_customer = Invoice.allCustomer;
-Invoice.all_any = Invoice.allAny;
-Invoice.destroy_all = Invoice.destroyAll;
+Invoice.all_customer = function (...args) {
+  console.warn('[DEPRECATED] Invoice.all_customer is deprecated. Use Invoice.allCustomer instead.');
+  return Invoice.allCustomer.apply(this, args);
+};
+Invoice.all_any = function (...args) {
+  console.warn('[DEPRECATED] Invoice.all_any is deprecated. Use Invoice.allAny instead.');
+  return Invoice.allAny.apply(this, args);
+};
+Invoice.destroy_all = function (...args) {
+  console.warn('[DEPRECATED] Invoice.destroy_all is deprecated. Use Invoice.destroyAll instead.');
+  return Invoice.destroyAll.apply(this, args);
+};
 
 Invoice.retrieve = Resource._method('GET', '/v1/invoices{/uuid}');
 

--- a/lib/chartmogul/plan-group.js
+++ b/lib/chartmogul/plan-group.js
@@ -21,6 +21,9 @@ PlanGroup.all = function (config, params) {
 };
 
 // Deprecated snake_case alias
-PlanGroup.all_any = PlanGroup.allAny;
+PlanGroup.all_any = function (...args) {
+  console.warn('[DEPRECATED] PlanGroup.all_any is deprecated. Use PlanGroup.allAny instead.');
+  return PlanGroup.allAny.apply(this, args);
+};
 
 module.exports = PlanGroup;

--- a/lib/chartmogul/plan-group.js
+++ b/lib/chartmogul/plan-group.js
@@ -10,14 +10,17 @@ class PlanGroup extends Resource {
 }
 
 // @Override
-PlanGroup.all_any = Resource._method('GET', '/v1/plan_groups');
+PlanGroup.allAny = Resource._method('GET', '/v1/plan_groups');
 
 PlanGroup.all = function (config, params) {
   if (typeof params === 'string') {
     return PlanGroupPlans.all.apply(this, arguments);
   } else {
-    return PlanGroup.all_any.apply(this, arguments);
+    return PlanGroup.allAny.apply(this, arguments);
   }
 };
+
+// Deprecated snake_case alias
+PlanGroup.all_any = PlanGroup.allAny;
 
 module.exports = PlanGroup;

--- a/test/chartmogul/invoice.js
+++ b/test/chartmogul/invoice.js
@@ -277,7 +277,7 @@ describe('Invoices', () => {
       .delete('/v1/data_sources/ds_cff3a63c-3915-435e-a675-85a8a8ef4454/customers/cus_9bf6482d-01e5-4944-957d-5bc730d2cda3/invoices')
       .reply(204, {});
 
-    return Invoice.destroy_all(config, 'ds_cff3a63c-3915-435e-a675-85a8a8ef4454', 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3')
+    return Invoice.destroyAll(config, 'ds_cff3a63c-3915-435e-a675-85a8a8ef4454', 'cus_9bf6482d-01e5-4944-957d-5bc730d2cda3')
       .then(res => {
         expect(res).to.be.deep.equal({});
       });


### PR DESCRIPTION
## Summary
- Renames `Invoice.destroy_all` → `Invoice.destroyAll`
- Renames `Invoice.all_customer` → `Invoice.allCustomer` (internal dispatch helper)
- Renames `Invoice.all_any` → `Invoice.allAny` (internal dispatch helper)
- Renames `PlanGroup.all_any` → `PlanGroup.allAny` (internal dispatch helper)
- Snake_case aliases preserved as deprecated for backwards compatibility

## Backwards compatibility

| Change | Breaking? |
|---|---|
| `Invoice.destroyAll` is the new primary name | No — `Invoice.destroy_all` still works as a deprecated alias |
| `Invoice.allCustomer` / `Invoice.allAny` renamed | No — these are internal dispatch helpers; deprecated aliases preserved |
| `PlanGroup.allAny` renamed | No — internal dispatch helper; deprecated alias preserved |

## Testing instructions

```javascript
const ChartMogul = require('chartmogul-node');
const config = new ChartMogul.Config('YOUR_API_KEY');

// New camelCase method
await ChartMogul.Invoice.destroyAll(config, 'ds_...', 'cus_...');

// Deprecated alias still works
await ChartMogul.Invoice.destroy_all(config, 'ds_...', 'cus_...');
```

## Test plan
- [x] All 249 tests pass
- [x] Existing test updated to use `destroyAll`
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)