### PR TITLE
Fix npm publish step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm install -g npm@11.12.1
-
       - name: Verify version matches tag
         run: |
           PKG_VERSION="v$(node -p 'require("./package.json").version')"


### PR DESCRIPTION
The v3.12.0 release workflow [failed](https://github.com/chartmogul/chartmogul-node/actions/runs/24558916057/job/71802399558) because npm cannot cleanly replace itself on Node 22.22.2 (`MODULE_NOT_FOUND` on `promise-retry` during self-install).

This PR removes `npm install -g npm@11.12.1` from the publish job - Node 22 already ships with npm >= 11.5.1 (the minimum for OIDC trusted publishing)

## TODO

- [x] Merge, then `bin/release patch`, that should release v3.12.1 to confirm the publish job fix has worked
- [x] Do manual `git checkout v3.12.0  && npm publish --provenance` for v3.12.0 that has failed