### PR TITLE
Fix npm OIDC publish: remove pinned npm, use Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,6 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm install -g npm@11.12.1
-
       - name: Verify version matches tag
         run: |
           PKG_VERSION="v$(node -p 'require("./package.json").version')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify version matches tag


### PR DESCRIPTION
There's a [known issue](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd) and [npm/cli repo comment to use Node 24](https://github.com/npm/cli/issues/8730#issuecomment-3572003280). Node 22's bundled npm has a bug with OIDC trusted publishing that produces a misleading 404

> npm error code E404
> npm error 404 Not Found - PUT https://registry.npmjs.org/chartmogul-node - Not found

The fix is to use Node 24 in the publish job.

## TODO

- [x] merge, `bin/release patch`, and verify the publish job succeeds on npm
- [x] then manually publish v3.12.0 and v3.12.1 to NPM