### PR TITLE
Deprecate Subscription.all (import subscriptions endpoint)

### DIFF
--- a/lib/chartmogul/subscription.js
+++ b/lib/chartmogul/subscription.js
@@ -8,7 +8,11 @@ class Subscription extends Resource {
   }
 }
 
-// @Override
-Subscription.all = Resource._method('GET', '/v1/import/customers/{customerUuid}/subscriptions');
+// DEPRECATED: Use ChartMogul.Metrics.Customer.subscriptions instead
+const _originalAll = Resource._method('GET', '/v1/import/customers/{customerUuid}/subscriptions');
+Subscription.all = function deprecatedAll (config, customerUuid, data, callback) {
+  console.warn('[DEPRECATED] Subscription.all is deprecated. Use ChartMogul.Metrics.Customer.subscriptions instead.');
+  return _originalAll.call(this, config, customerUuid, data, callback);
+};
 
 module.exports = Subscription;


### PR DESCRIPTION
- `Subscription.all` calls `GET /v1/import/customers/{customerUuid}/subscriptions`, which is deprecated on the API side.
- Wraps `Subscription.all` to emit a `console.warn` deprecation message before delegating to the original method, mirroring the pattern already used for `Customer.connectSubscriptions` and `Customer.disconnectSubscriptions`.
- Existing callers continue to work; consumers should migrate to `ChartMogul.Metrics.Customer.subscriptions`.
