### PR TITLE
Release v3.12.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chartmogul-node",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chartmogul-node",
-      "version": "3.12.2",
+      "version": "3.12.3",
       "license": "MIT",
       "dependencies": {
         "retry": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartmogul-node",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "Official Chartmogul API Node.js Client",
   "main": "lib/chartmogul.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump package version to **v3.12.3** so the security overrides for `brace-expansion` and `js-yaml` (#151) can be published to npm for internal repos and clients.

## Test plan
- [x] CI green on this PR
- [ ] After merge, tag `v3.12.3` (or run `bin/release.sh` remaining steps) so the release workflow publishes to npm
- [ ] Confirm `chartmogul-node@3.12.3` appears on npm


Made with [Cursor](https://cursor.com)